### PR TITLE
Remove valid property name check

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/PropertySpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/PropertySpec.kt
@@ -164,20 +164,17 @@ class PropertySpec private constructor(
 
   companion object {
     @JvmStatic fun builder(name: String, type: TypeName, vararg modifiers: Modifier): Builder {
-      require(name.isName) { "not a valid name: $name" }
       return Builder(name, type)
           .addModifiers(*modifiers)
     }
 
     @JvmStatic fun varBuilder(name: String, type: TypeName, vararg modifiers: Modifier): Builder {
-      require(name.isName) { "not a valid name: $name" }
       return Builder(name, type)
           .mutable(true)
           .addModifiers(*modifiers)
     }
 
     @JvmStatic fun abstractBuilder(name: String, type: TypeName, vararg modifiers: Modifier): Builder {
-      require(name.isName) { "not a valid name: $name" }
       return Builder(name, type)
          .mutable(true)
          .addModifiers(*modifiers)

--- a/src/test/java/io/outfoxx/swiftpoet/test/PropertySpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/PropertySpecTests.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.swiftpoet.test
+
+import io.outfoxx.swiftpoet.*
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("PropertySpec tests")
+class PropertySpecTests {
+
+  @Test
+  @DisplayName("Escapes names which are keywords")
+  fun escapeName() {
+    val property = PropertySpec.builder("extension", STRING).build()
+    assertThat(property.toString(), equalTo("let `extension`: Swift.String"))
+  }
+
+}


### PR DESCRIPTION
A name will automatically be escaped if it matches a keyword or is not a valid bare identifier.

Closes #2.