### PR TITLE
Escape reserved type names

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/DeclaredTypeName.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/DeclaredTypeName.kt
@@ -43,12 +43,6 @@ class DeclaredTypeName internal constructor(
 
   val compoundName get() = simpleNames.joinToString("") { it.capitalize() }
 
-  init {
-    for (i in 1 until names.size) {
-      require(names[i].isName) { "part ${names[i]} is keyword" }
-    }
-  }
-
   /**
    * Returns the enclosing type, like [Map] for `Map.Entry`. Returns null if this type
    * is not nested in another type.

--- a/src/main/java/io/outfoxx/swiftpoet/TypeSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/TypeSpec.kt
@@ -251,10 +251,6 @@ class TypeSpec private constructor(
     internal val isStruct = kind is Kind.Struct
     internal val isProtocol = kind is Kind.Protocol
 
-    init {
-      require(name.isName) { "not a valid name: $name" }
-    }
-
     fun addKdoc(format: String, vararg args: Any) = apply {
       kdoc.add(format, *args)
     }

--- a/src/main/java/io/outfoxx/swiftpoet/Util.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/Util.kt
@@ -209,6 +209,8 @@ private val KEYWORDS = setOf(
    "throw",
    "throws",
    "true",
-   "try"
+   "try",
 
+   "Type",
+   "Self"
 )

--- a/src/test/java/io/outfoxx/swiftpoet/test/ClassSpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/ClassSpecTests.kt
@@ -57,6 +57,26 @@ class ClassSpecTests {
   }
 
   @Test
+  @DisplayName("Escapes reserved type names")
+  fun testGenReservedClassName() {
+    val testClass = TypeSpec.classBuilder("Type").build()
+
+    val out = StringWriter()
+    testClass.emit(CodeWriter(out))
+
+    assertThat(
+        out.toString(),
+        equalTo(
+        """
+        class `Type` {
+        }
+
+        """.trimIndent()
+        )
+    )
+  }
+
+  @Test
   @DisplayName("Generates modifiers in order")
   fun testGenModifiersInOrder() {
     val testClass = TypeSpec.classBuilder("Test")

--- a/src/test/java/io/outfoxx/swiftpoet/test/PropertySpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/PropertySpecTests.kt
@@ -32,4 +32,10 @@ class PropertySpecTests {
     assertThat(property.toString(), equalTo("let `extension`: Swift.String"))
   }
 
+  @Test
+  @DisplayName("Escapes types which are keywords")
+  fun escapeType() {
+    val property = PropertySpec.builder("type", DeclaredTypeName(listOf("Foo", "Type"))).build()
+    assertThat(property.toString(), equalTo("let type: Foo.`Type`"))
+  }
 }


### PR DESCRIPTION
This allows things like:
```
struct `Type` {}
```
and makes sure it's escaped properly, both in its declaration and when referenced.