### PR TITLE
Create output directory if it does not exist

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/FileSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/FileSpec.kt
@@ -60,6 +60,7 @@ class FileSpec private constructor(builder: FileSpec.Builder) {
     require(Files.notExists(directory) || Files.isDirectory(directory)) {
       "path $directory exists but is not a directory."
     }
+    Files.createDirectories(directory)
     val outputPath = directory.resolve("$name.swift")
     OutputStreamWriter(Files.newOutputStream(outputPath), UTF_8).use { writer -> writeTo(writer) }
   }


### PR DESCRIPTION
KotlinPoet always invokes this method even when you don't have a package from https://github.com/square/kotlinpoet/pull/500. Since Swift isn't nesting code in folders there's less of a need for this change. But without it you force the caller to remember to do it themselves.

Additionally, the `Files.notExists` check above doesn't make sense without this change since it allows the absence of the directory to pass the check and then immediately will crash trying to write to the non-existent dir.

That being said, doing this yourself isn't hard, it's just that you have to remember.

Up to you. I don't think it's an essential change just figured I'd throw it up and see what you thought.