### PR TITLE
Remove requirement that enums have at least one case

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/TypeSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/TypeSpec.kt
@@ -354,10 +354,6 @@ class TypeSpec private constructor(
     }
 
     fun build(): TypeSpec {
-      require(!isEnum || enumCases.isNotEmpty()) {
-        "at least one enum constant is required for $name"
-      }
-
       return TypeSpec(this)
     }
   }

--- a/src/test/java/io/outfoxx/swiftpoet/test/EnumSpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/EnumSpecTests.kt
@@ -207,4 +207,24 @@ class EnumSpecTests {
     assertThat(testEnumBldr.enumCases.keys, hasItems("A"))
   }
 
+  @Test
+  @DisplayName("Allow enums with no cases")
+  fun testNoCases() {
+    val testClass = TypeSpec.enumBuilder("Test")
+      .build()
+    val out = StringWriter()
+    testClass.emit(CodeWriter(out))
+
+    assertThat(
+      out.toString(),
+      equalTo(
+        """
+            enum Test {
+            }
+
+          """.trimIndent()
+      )
+    )
+  }
+
 }


### PR DESCRIPTION
An enum with no cases is valid in Swift, and such a definition is sometimes useful to provide "namespacing", such as:

```
enum Foo {
	struct Bar {…}
}
```