### PR TITLE
Support generating switch via `beginControlFlow`/`endControlFlow` without indent

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/CodeBlock.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/CodeBlock.kt
@@ -349,6 +349,18 @@ class CodeBlock private constructor(
     }
 
     /**
+     * @param controlFlowName the control flow construct "if", "switch", "else if", etc.
+     * @param controlFlowCode code for control flow, such as "foo == 5"
+     *     Shouldn't contain braces or newline characters.
+     */
+    fun beginControlFlow(controlFlowName: String, controlFlowCode: String, vararg args: Any?) = apply {
+      add("$controlFlowName $controlFlowCode {\n", *args)
+      if (controlFlowName != "switch") {
+        indent()
+      }
+    }
+
+    /**
      * @param controlFlow the control flow construct and its code, such as "else if (foo == 10)".
      *     Shouldn't contain braces or newline characters.
      */
@@ -360,6 +372,13 @@ class CodeBlock private constructor(
 
     fun endControlFlow() = apply {
       unindent()
+      add("}\n")
+    }
+
+    fun endControlFlow(controlFlowName: String) = apply {
+      if (controlFlowName != "switch") {
+        unindent()
+      }
       add("}\n")
     }
 

--- a/src/main/java/io/outfoxx/swiftpoet/CodeBlock.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/CodeBlock.kt
@@ -340,16 +340,7 @@ class CodeBlock private constructor(
     }
 
     /**
-     * @param controlFlow the control flow construct and its code, such as "if (foo == 5)".
-     *     Shouldn't contain braces or newline characters.
-     */
-    fun beginControlFlow(controlFlow: String, vararg args: Any?) = apply {
-      add(controlFlow + " {\n", *args)
-      indent()
-    }
-
-    /**
-     * @param controlFlowName the control flow construct "if", "switch", "else if", etc.
+     * @param controlFlowName the control flow construct (e.g. "if", "switch", etc.).
      * @param controlFlowCode code for control flow, such as "foo == 5"
      *     Shouldn't contain braces or newline characters.
      */
@@ -361,18 +352,14 @@ class CodeBlock private constructor(
     }
 
     /**
-     * @param controlFlow the control flow construct and its code, such as "else if (foo == 10)".
+     * @param controlFlowName the control flow construct (e.g. "else if").
+     * @param controlFlowCode the control flow construct and its code, such as "else if (foo == 10)".
      *     Shouldn't contain braces or newline characters.
      */
-    fun nextControlFlow(controlFlow: String, vararg args: Any?) = apply {
+    fun nextControlFlow(controlFlowName: String, controlFlowCode: String, vararg args: Any?) = apply {
       unindent()
-      add("} $controlFlow {\n", *args)
+      add("} $controlFlowName $controlFlowCode {\n", *args)
       indent()
-    }
-
-    fun endControlFlow() = apply {
-      unindent()
-      add("}\n")
     }
 
     fun endControlFlow(controlFlowName: String) = apply {

--- a/src/main/java/io/outfoxx/swiftpoet/FunctionSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/FunctionSpec.kt
@@ -261,23 +261,25 @@ class FunctionSpec private constructor(
     }
 
     /**
-     * @param controlFlow the control flow construct and its code, such as "if (foo == 5)".
-     * * Shouldn't contain braces or newline characters.
+     * @param controlFlowName the control flow construct (e.g. "if", "switch", etc.).
+     * @param controlFlowCode code for control flow, such as "foo == 5"
+     *     Shouldn't contain braces or newline characters.
      */
-    fun beginControlFlow(controlFlow: String, vararg args: Any) = apply {
-      body.beginControlFlow(controlFlow, *args)
+    fun beginControlFlow(controlFlowName: String, controlFlowCode: String, vararg args: Any) = apply {
+      body.beginControlFlow(controlFlowName, controlFlowCode, *args)
     }
 
     /**
-     * @param controlFlow the control flow construct and its code, such as "else if (foo == 10)".
-     * *     Shouldn't contain braces or newline characters.
+     * @param controlFlowName the control flow construct (e.g. "else if").
+     * @param controlFlowCode the control flow construct and its code, such as "else if (foo == 10)".
+     *     Shouldn't contain braces or newline characters.
      */
-    fun nextControlFlow(controlFlow: String, vararg args: Any) = apply {
-      body.nextControlFlow(controlFlow, *args)
+    fun nextControlFlow(controlFlowName: String, controlFlowCode: String, vararg args: Any?) = apply {
+      body.nextControlFlow(controlFlowName, controlFlowCode, *args)
     }
 
-    fun endControlFlow() = apply {
-      body.endControlFlow()
+    fun endControlFlow(controlFlowName: String) = apply {
+      body.endControlFlow(controlFlowName)
     }
 
     fun addStatement(format: String, vararg args: Any) = apply {

--- a/src/test/java/io/outfoxx/swiftpoet/test/CodeBlockTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/CodeBlockTests.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.swiftpoet.test
+
+import io.outfoxx.swiftpoet.CodeBlock
+import io.outfoxx.swiftpoet.CodeWriter
+import org.hamcrest.CoreMatchers
+import org.hamcrest.MatcherAssert
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.StringWriter
+
+class CodeBlockTests {
+
+  @Test
+  @DisplayName("Generates 'if' control flow with indent")
+  fun testGenIfControlFlowWithIndent() {
+
+    val code = CodeBlock.builder()
+       .beginControlFlow("if", "x == %L", 5)
+       .addStatement("print(\"It's five!\")")
+       .endControlFlow("if")
+       .build()
+
+    val out = StringWriter()
+    CodeWriter(out).emitCode(code)
+
+    MatcherAssert.assertThat(
+       out.toString(),
+       CoreMatchers.equalTo(
+          """
+            if x == 5 {
+              print("It's five!")
+            }
+            
+          """.trimIndent()
+       )
+    )
+  }
+
+  @Test
+  @DisplayName("Generates 'switch' control flow without indent")
+  fun testGenSwitchControlFlowWithoutIndent() {
+
+    val code = CodeBlock.builder()
+       .beginControlFlow("switch", "x")
+       .addStatement("case %L: print(\"It's five!\")", 5)
+       .endControlFlow("switch")
+       .build()
+
+    val out = StringWriter()
+    CodeWriter(out).emitCode(code)
+
+    MatcherAssert.assertThat(
+       out.toString(),
+       CoreMatchers.equalTo(
+          """
+            switch x {
+            case 5: print("It's five!")
+            }
+            
+          """.trimIndent()
+       )
+    )
+  }
+
+}


### PR DESCRIPTION
Fixes #11 