### PR TITLE
Support guarding & documenting imports & members

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/FileMemberSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/FileMemberSpec.kt
@@ -1,0 +1,72 @@
+package io.outfoxx.swiftpoet
+
+class FileMemberSpec internal constructor(builder: Builder) {
+  val kdoc = builder.kdoc.build()
+  val member = builder.member
+  val guardTest = builder.guardTest.build()
+
+  internal fun emit(out: CodeWriter): CodeWriter {
+
+    out.emitKdoc(kdoc)
+
+    if (guardTest.isNotEmpty()) {
+      out.emit("#if ")
+      out.emitCode(guardTest)
+      out.emit("\n")
+    }
+
+    when (member) {
+      is TypeSpec -> member.emit(out)
+      is FunctionSpec -> member.emit(out, null, setOf(Modifier.PUBLIC))
+      is PropertySpec -> member.emit(out, setOf(Modifier.PUBLIC))
+      is TypeAliasSpec -> member.emit(out)
+      is ExtensionSpec -> member.emit(out)
+      else -> throw AssertionError()
+    }
+
+    if (guardTest.isNotEmpty()) {
+      out.emit("#endif")
+      out.emit("\n")
+    }
+
+    return out
+  }
+
+  class Builder internal constructor(internal val member: Any) {
+    internal val kdoc = CodeBlock.builder()
+    internal val guardTest = CodeBlock.builder()
+
+    fun addKdoc(format: String, vararg args: Any) = apply {
+      kdoc.add(format, *args)
+    }
+
+    fun addKdoc(block: CodeBlock) = apply {
+      kdoc.add(block)
+    }
+
+    fun addGuard(test: CodeBlock) = apply {
+      guardTest.add(test)
+    }
+
+    fun addGuard(format: String, vararg args: Any) = apply {
+      addGuard(CodeBlock.of(format, args))
+    }
+
+    fun build(): FileMemberSpec {
+      return FileMemberSpec(this)
+    }
+  }
+
+  companion object {
+    @JvmStatic fun builder(member: TypeSpec) = Builder(member)
+
+    @JvmStatic fun builder(member: FunctionSpec) = Builder(member)
+
+    @JvmStatic fun builder(member: PropertySpec) = Builder(member)
+
+    @JvmStatic fun builder(member: TypeAliasSpec) = Builder(member)
+
+    @JvmStatic fun builder(member: ExtensionSpec) = Builder(member)
+  }
+
+}

--- a/src/main/java/io/outfoxx/swiftpoet/ImportSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/ImportSpec.kt
@@ -17,22 +17,77 @@
 package io.outfoxx.swiftpoet
 
 class ImportSpec internal constructor(
-   internal val name: String,
-   attributes: List<AttributeSpec> = listOf()
-) : AttributedSpec(attributes), Comparable<ImportSpec> {
+  builder: ImportSpec.Builder
+) : AttributedSpec(builder.attributes.toImmutableList()), Comparable<ImportSpec> {
+  val name = builder.name
+  val kdoc = builder.kdoc.build()
+  val guardTest = builder.guardTest.build()
 
   private val importString = buildString {
     append(name)
   }
 
   internal fun emit(out: CodeWriter): CodeWriter {
+
+    out.emitKdoc(kdoc)
+
+    if (guardTest.isNotEmpty()) {
+      out.emit("#if ")
+      out.emitCode(guardTest)
+      out.emit("\n")
+    }
+
     out.emitAttributes(attributes, suffix = "")
     out.emit("import $name")
+
+    if (guardTest.isNotEmpty()) {
+      out.emit("\n")
+      out.emit("#endif")
+    }
+
     return out
   }
 
   override fun toString() = importString
 
   override fun compareTo(other: ImportSpec) = importString.compareTo(other.importString)
+
+  class Builder internal constructor(internal val name: String) {
+    internal val kdoc = CodeBlock.builder()
+    internal val attributes = mutableListOf<AttributeSpec>()
+    internal val guardTest = CodeBlock.builder()
+
+    fun addKdoc(format: String, vararg args: Any) = apply {
+      kdoc.add(format, *args)
+    }
+
+    fun addKdoc(block: CodeBlock) = apply {
+      kdoc.add(block)
+    }
+
+    fun addAttribute(attribute: AttributeSpec) = apply {
+      this.attributes += attribute
+    }
+
+    fun addAttribute(name: String, vararg arguments: String) = apply {
+      this.attributes += AttributeSpec.builder(name).addArguments(arguments.toList()).build()
+    }
+
+    fun addGuard(test: CodeBlock) = apply {
+      guardTest.add(test)
+    }
+
+    fun addGuard(format: String, vararg args: Any) = apply {
+      addGuard(CodeBlock.of(format, args))
+    }
+
+    fun build(): ImportSpec {
+      return ImportSpec(this)
+    }
+  }
+
+  companion object {
+    @JvmStatic fun builder(name: String) = Builder(name)
+  }
 
 }


### PR DESCRIPTION
Allows any file import or member to be guarded (`#if/#endif`) and/or documented.

Documentation at the member level will be output immediately prior to the member spec's own documentation.