### PR TITLE
Add AnyTypeSpec as ancestor to TypeSpec & TypeAliasSpec

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/AnyTypeSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/AnyTypeSpec.kt
@@ -1,0 +1,10 @@
+package io.outfoxx.swiftpoet
+
+abstract class AnyTypeSpec(
+  val name: String,
+  attributes: List<AttributeSpec> = listOf()
+) : AttributedSpec(attributes.toImmutableList()) {
+
+  internal abstract fun emit(codeWriter: CodeWriter)
+
+}

--- a/src/main/java/io/outfoxx/swiftpoet/ExtensionSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/ExtensionSpec.kt
@@ -28,7 +28,6 @@ class ExtensionSpec private constructor(builder: ExtensionSpec.Builder) {
   val propertySpecs = builder.propertySpecs.toImmutableList()
   val funSpecs = builder.functionSpecs.toImmutableList()
   val typeSpecs = builder.typeSpecs.toImmutableList()
-  val typeAliasSpecs = builder.typeAliasSpecs.toImmutableList()
 
   fun toBuilder(): Builder {
     val builder = Builder(extendedType)
@@ -37,7 +36,6 @@ class ExtensionSpec private constructor(builder: ExtensionSpec.Builder) {
     builder.propertySpecs += propertySpecs
     builder.functionSpecs += funSpecs
     builder.typeSpecs += typeSpecs
-    builder.typeAliasSpecs += typeAliasSpecs
     return builder
   }
 
@@ -93,14 +91,7 @@ class ExtensionSpec private constructor(builder: ExtensionSpec.Builder) {
       // Types.
       for (typeSpec in typeSpecs) {
         if (!firstMember) codeWriter.emit("\n")
-        typeSpec.emit(codeWriter, false)
-        firstMember = false
-      }
-
-      // Type aliases.
-      for (typeAliasSpec in typeAliasSpecs) {
-        if (!firstMember) codeWriter.emit("\n")
-        typeAliasSpec.emit(codeWriter)
+        typeSpec.emit(codeWriter)
         firstMember = false
       }
 
@@ -132,8 +123,7 @@ class ExtensionSpec private constructor(builder: ExtensionSpec.Builder) {
     internal val conditionalConstraints = mutableListOf<TypeVariableName>()
     internal val propertySpecs = mutableListOf<PropertySpec>()
     internal val functionSpecs = mutableListOf<FunctionSpec>()
-    internal val typeSpecs = mutableListOf<TypeSpec>()
-    internal val typeAliasSpecs = mutableListOf<TypeAliasSpec>()
+    internal val typeSpecs = mutableListOf<AnyTypeSpec>()
 
     fun addDoc(format: String, vararg args: Any) = apply {
       doc.add(format, *args)
@@ -179,20 +169,12 @@ class ExtensionSpec private constructor(builder: ExtensionSpec.Builder) {
       functionSpecs += functionSpec
     }
 
-    fun addTypes(typeSpecs: Iterable<TypeSpec>) = apply {
+    fun addTypes(typeSpecs: Iterable<AnyTypeSpec>) = apply {
       this.typeSpecs += typeSpecs
     }
 
-    fun addType(typeSpec: TypeSpec) = apply {
+    fun addType(typeSpec: AnyTypeSpec) = apply {
       typeSpecs += typeSpec
-    }
-
-    fun addTypeAliases(typeAliasSpecs: Iterable<TypeAliasSpec>) = apply {
-      this.typeAliasSpecs += typeAliasSpecs
-    }
-
-    fun addTypeAlias(typeAliasSpec: TypeAliasSpec) = apply {
-      typeAliasSpecs += typeAliasSpec
     }
 
     fun build(): ExtensionSpec {

--- a/src/main/java/io/outfoxx/swiftpoet/FileMemberSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/FileMemberSpec.kt
@@ -58,13 +58,11 @@ class FileMemberSpec internal constructor(builder: Builder) {
   }
 
   companion object {
-    @JvmStatic fun builder(member: TypeSpec) = Builder(member)
+    @JvmStatic fun builder(member: AnyTypeSpec) = Builder(member)
 
     @JvmStatic fun builder(member: FunctionSpec) = Builder(member)
 
     @JvmStatic fun builder(member: PropertySpec) = Builder(member)
-
-    @JvmStatic fun builder(member: TypeAliasSpec) = Builder(member)
 
     @JvmStatic fun builder(member: ExtensionSpec) = Builder(member)
   }

--- a/src/main/java/io/outfoxx/swiftpoet/FileSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/FileSpec.kt
@@ -137,7 +137,7 @@ class FileSpec private constructor(builder: FileSpec.Builder) {
       members += memberSpec
     }
 
-    fun addType(typeSpec: TypeSpec) = apply {
+    fun addType(typeSpec: AnyTypeSpec) = apply {
       addMember(FileMemberSpec.builder(typeSpec).build())
     }
 
@@ -150,10 +150,6 @@ class FileSpec private constructor(builder: FileSpec.Builder) {
 
     fun addProperty(propertySpec: PropertySpec) = apply {
       addMember(FileMemberSpec.builder(propertySpec).build())
-    }
-
-    fun addTypeAlias(typeAliasSpec: TypeAliasSpec) = apply {
-      addMember(FileMemberSpec.builder(typeAliasSpec).build())
     }
 
     fun addExtension(extensionSpec: ExtensionSpec) = apply {

--- a/src/main/java/io/outfoxx/swiftpoet/TypeAliasSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/TypeAliasSpec.kt
@@ -19,15 +19,18 @@ package io.outfoxx.swiftpoet
 import io.outfoxx.swiftpoet.Modifier.*
 
 /** A generated typealias declaration */
-class TypeAliasSpec private constructor(builder: TypeAliasSpec.Builder) {
-  val name = builder.name
+class TypeAliasSpec private constructor(
+  builder: TypeAliasSpec.Builder
+) : AnyTypeSpec(builder.name, builder.attributes.toImmutableList()) {
+
   val type = builder.type
   val modifiers = builder.modifiers.toImmutableSet()
   val typeVariables = builder.typeVariables.toImmutableList()
   val doc = builder.doc.build()
 
-  internal fun emit(codeWriter: CodeWriter) {
+  override fun emit(codeWriter: CodeWriter) {
     codeWriter.emitDoc(doc)
+    codeWriter.emitAttributes(attributes)
     codeWriter.emitModifiers(modifiers)
     codeWriter.emitCode("typealias %L", name)
     codeWriter.emitTypeVariables(typeVariables)
@@ -58,12 +61,29 @@ class TypeAliasSpec private constructor(builder: TypeAliasSpec.Builder) {
     internal val name: String,
     internal val type: TypeName
   ) {
+    internal val doc = CodeBlock.builder()
+    internal val attributes = mutableListOf<AttributeSpec>()
     internal val modifiers = mutableSetOf<Modifier>()
     internal val typeVariables = mutableSetOf<TypeVariableName>()
-    internal val doc = CodeBlock.builder()
 
     init {
       require(name.isName) { "not a valid name: $name" }
+    }
+
+    fun addDoc(format: String, vararg args: Any) = apply {
+      doc.add(format, *args)
+    }
+
+    fun addDoc(block: CodeBlock) = apply {
+      doc.add(block)
+    }
+
+    fun addAttribute(attribute: AttributeSpec) = apply {
+      this.attributes += attribute
+    }
+
+    fun addAttribute(name: String, vararg arguments: String) = apply {
+      this.attributes += AttributeSpec.builder(name).addArguments(arguments.toList()).build()
     }
 
     fun addModifiers(vararg modifiers: Modifier) = apply {
@@ -83,14 +103,6 @@ class TypeAliasSpec private constructor(builder: TypeAliasSpec.Builder) {
 
     fun addTypeVariable(typeVariable: TypeVariableName) = apply {
       typeVariables += typeVariable
-    }
-
-    fun addDoc(format: String, vararg args: Any) = apply {
-      doc.add(format, *args)
-    }
-
-    fun addDoc(block: CodeBlock) = apply {
-      doc.add(block)
     }
 
     fun build() = TypeAliasSpec(this)

--- a/src/test/java/io/outfoxx/swiftpoet/test/ClassSpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/ClassSpecTests.kt
@@ -436,7 +436,7 @@ class ClassSpecTests {
   @DisplayName("Generates nested type alias")
   fun testNestedTypeAlias() {
     val testExt = TypeSpec.classBuilder("MyClass")
-        .addTypeAlias(TypeAliasSpec.builder("Keys", typeName("Other.Keys")).build())
+        .addType(TypeAliasSpec.builder("Keys", typeName("Other.Keys")).build())
         .build()
 
     val out = StringWriter()

--- a/src/test/java/io/outfoxx/swiftpoet/test/ExtensionSpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/ExtensionSpecTests.kt
@@ -105,7 +105,7 @@ class ExtensionSpecTests {
   @DisplayName("Generates nested type alias")
   fun testNestedTypeAlias() {
     val testExt = ExtensionSpec.builder(DeclaredTypeName.typeName("Swift.Array"))
-        .addTypeAlias(TypeAliasSpec.builder("Keys", DeclaredTypeName.typeName("Other.Keys")).build())
+        .addType(TypeAliasSpec.builder("Keys", DeclaredTypeName.typeName("Other.Keys")).build())
        .build()
 
     val out = StringWriter()

--- a/src/test/java/io/outfoxx/swiftpoet/test/TypeAliasSpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/TypeAliasSpecTests.kt
@@ -32,7 +32,7 @@ import java.io.StringWriter
 class TypeAliasSpecTests {
 
   @Test
-  @DisplayName("Generates documentation before class definition")
+  @DisplayName("Generates documentation before type definition")
   fun testGenDoc() {
     val testAlias = TypeAliasSpec.builder("MyNumber", INT)
        .addDoc("this is a comment\n")
@@ -48,6 +48,28 @@ class TypeAliasSpecTests {
             /**
              * this is a comment
              */
+            typealias MyNumber = Swift.Int
+
+          """.trimIndent()
+       )
+    )
+  }
+
+  @Test
+  @DisplayName("Generates attributes before type definition")
+  fun testGenAttrs() {
+    val testAlias = TypeAliasSpec.builder("MyNumber", INT)
+       .addAttribute("available", "swift 5.1")
+       .build()
+
+    val out = StringWriter()
+    testAlias.emit(CodeWriter(out))
+
+    assertThat(
+       out.toString(),
+       equalTo(
+          """
+            @available(swift 5.1)
             typealias MyNumber = Swift.Int
 
           """.trimIndent()


### PR DESCRIPTION
Removes all specializations of functions for `TypeSpec` & `TypeAliasSpec`; now all use single set of `AnyTypeSpec` methods.

Fixes #17 