### PR TITLE
Replace remaining incorrect usages to TypeSpec with AnyTypeSpec

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/AnyTypeSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/AnyTypeSpec.kt
@@ -21,6 +21,8 @@ abstract class AnyTypeSpec(
   attributes: List<AttributeSpec> = listOf()
 ) : AttributedSpec(attributes.toImmutableList()) {
 
+  internal open val typeSpecs: List<AnyTypeSpec> = listOf()
+
   internal abstract fun emit(codeWriter: CodeWriter)
 
 }

--- a/src/main/java/io/outfoxx/swiftpoet/CodeBlock.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/CodeBlock.kt
@@ -325,7 +325,7 @@ class CodeBlock private constructor(
       is ParameterSpec -> o.parameterName
       is PropertySpec -> o.name
       is FunctionSpec -> o.name
-      is TypeSpec -> o.name
+      is AnyTypeSpec -> o.name
       else -> throw IllegalArgumentException("expected name but was " + o)
     }
 
@@ -335,7 +335,7 @@ class CodeBlock private constructor(
 
     private fun argToType(o: Any?) = when (o) {
       is TypeName -> o
-      is TypeSpec -> DeclaredTypeName(listOf("", o.name))
+      is AnyTypeSpec -> DeclaredTypeName(listOf("", o.name))
       else -> throw IllegalArgumentException("expected type but was " + o)
     }
 

--- a/src/main/java/io/outfoxx/swiftpoet/CodeWriter.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/CodeWriter.kt
@@ -35,7 +35,7 @@ internal class CodeWriter constructor(
   private var doc = false
   private var comment = false
   private var moduleName = NO_MODULE
-  private val typeSpecStack = mutableListOf<TypeSpec>()
+  private val typeSpecStack = mutableListOf<AnyTypeSpec>()
   private val importableTypes = mutableMapOf<String, DeclaredTypeName>()
   private var trailingNewline = false
 
@@ -65,7 +65,7 @@ internal class CodeWriter constructor(
     this.moduleName = NO_MODULE
   }
 
-  fun pushType(type: TypeSpec) = apply {
+  fun pushType(type: AnyTypeSpec) = apply {
     this.typeSpecStack.add(type)
   }
 
@@ -229,7 +229,7 @@ internal class CodeWriter constructor(
 
   private fun emitLiteral(o: Any?) {
     when (o) {
-      is TypeSpec -> o.emit(this)
+      is AnyTypeSpec -> o.emit(this)
       is PropertySpec -> o.emit(this, emptySet())
       is CodeBlock -> emitCode(o)
       else -> emit(o.toString())

--- a/src/main/java/io/outfoxx/swiftpoet/ExtensionSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/ExtensionSpec.kt
@@ -116,7 +116,7 @@ class ExtensionSpec private constructor(builder: ExtensionSpec.Builder) {
 
   override fun toString() = buildString { emit(CodeWriter(this)) }
 
-  class Builder internal constructor(internal val extendedType: TypeSpec) {
+  class Builder internal constructor(internal val extendedType: AnyTypeSpec) {
     internal val doc = CodeBlock.builder()
     internal val modifiers = mutableSetOf<Modifier>()
     internal val superTypes = mutableListOf<TypeName>()
@@ -183,7 +183,7 @@ class ExtensionSpec private constructor(builder: ExtensionSpec.Builder) {
   }
 
   companion object {
-    @JvmStatic fun builder(extendedType: TypeSpec) = Builder(extendedType)
+    @JvmStatic fun builder(extendedType: AnyTypeSpec) = Builder(extendedType)
     @JvmStatic fun builder(extendedType: TypeName) = Builder(TypeSpec.classBuilder(extendedType.name).build())
   }
 }

--- a/src/main/java/io/outfoxx/swiftpoet/FileMemberSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/FileMemberSpec.kt
@@ -32,10 +32,9 @@ class FileMemberSpec internal constructor(builder: Builder) {
     }
 
     when (member) {
-      is TypeSpec -> member.emit(out)
+      is AnyTypeSpec -> member.emit(out)
       is FunctionSpec -> member.emit(out, null, setOf(Modifier.PUBLIC))
       is PropertySpec -> member.emit(out, setOf(Modifier.PUBLIC))
-      is TypeAliasSpec -> member.emit(out)
       is ExtensionSpec -> member.emit(out)
       else -> throw AssertionError()
     }

--- a/src/main/java/io/outfoxx/swiftpoet/FileSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/FileSpec.kt
@@ -176,7 +176,7 @@ class FileSpec private constructor(builder: FileSpec.Builder) {
   }
 
   companion object {
-    @JvmStatic fun get(moduleName: String, typeSpec: TypeSpec): FileSpec {
+    @JvmStatic fun get(moduleName: String, typeSpec: AnyTypeSpec): FileSpec {
       return builder(moduleName, typeSpec.name).addType(typeSpec).build()
     }
 

--- a/src/main/java/io/outfoxx/swiftpoet/TypeSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/TypeSpec.kt
@@ -18,7 +18,7 @@ package io.outfoxx.swiftpoet
 
 import io.outfoxx.swiftpoet.Modifier.INTERNAL
 
-/** A generated class, protocol, or enum declaration.  */
+/** A generated class, struct, enum or protocol declaration. */
 class TypeSpec private constructor(
    builder: TypeSpec.Builder
 ) : AnyTypeSpec(builder.name, builder.attributes.toImmutableList()) {
@@ -35,7 +35,7 @@ class TypeSpec private constructor(
   val enumCases = builder.enumCases.toImmutableList()
   val propertySpecs = builder.propertySpecs.toImmutableList()
   val funSpecs = builder.functionSpecs.toImmutableList()
-  val typeSpecs = builder.typeSpecs.toImmutableList()
+  override val typeSpecs = builder.typeSpecs.toImmutableList()
 
   fun toBuilder(): Builder {
     val builder = Builder(kind, name)

--- a/src/test/java/io/outfoxx/swiftpoet/test/CodeBlockTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/CodeBlockTests.kt
@@ -18,6 +18,12 @@ package io.outfoxx.swiftpoet.test
 
 import io.outfoxx.swiftpoet.CodeBlock
 import io.outfoxx.swiftpoet.CodeWriter
+import io.outfoxx.swiftpoet.DeclaredTypeName
+import io.outfoxx.swiftpoet.DeclaredTypeName.Companion.typeName
+import io.outfoxx.swiftpoet.FileSpec
+import io.outfoxx.swiftpoet.FunctionSpec
+import io.outfoxx.swiftpoet.TypeAliasSpec
+import io.outfoxx.swiftpoet.TypeSpec
 import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert
 import org.junit.jupiter.api.DisplayName
@@ -25,6 +31,86 @@ import org.junit.jupiter.api.Test
 import java.io.StringWriter
 
 class CodeBlockTests {
+
+  @Test
+  @DisplayName("Generates correct types names for any type spec")
+  fun testGenCorrectTypeNames() {
+    val code = CodeBlock.builder()
+       .addStatement("let alias: %N", TypeAliasSpec.builder("TestAlias", typeName("Foundation.Data")).build())
+       .addStatement("let struct: %N", TypeSpec.structBuilder("TestStruct").build())
+       .build()
+
+    val out = StringWriter()
+    CodeWriter(out).emitCode(code)
+
+    MatcherAssert.assertThat(
+       out.toString(),
+       CoreMatchers.equalTo(
+          """
+            let alias: TestAlias
+            let struct: TestStruct
+
+          """.trimIndent()
+       )
+    )
+  }
+
+  @Test
+  @DisplayName("Generates correct types references for any type spec")
+  fun testGenCorrectTypeRefs() {
+    val code = CodeBlock.builder()
+      .addStatement("let alias: %T", TypeAliasSpec.builder("TestAlias", typeName("Foundation.Data")).build())
+      .addStatement("let struct: %T", TypeSpec.structBuilder("TestStruct").build())
+      .build()
+
+    val out = StringWriter()
+    CodeWriter(out).emitCode(code)
+
+    MatcherAssert.assertThat(
+      out.toString(),
+      CoreMatchers.equalTo(
+        """
+            let alias: TestAlias
+            let struct: TestStruct
+
+          """.trimIndent()
+      )
+    )
+  }
+
+  @Test
+  @DisplayName("Generates concise type names & imports for literally generated types")
+  fun testGenConciseTypeNamesAndImports() {
+    val dataTypeName = typeName("Foundation.Data")
+
+    val testFunc = FunctionSpec.builder("test")
+       .addCode("%L", TypeAliasSpec.builder("TestAlias", dataTypeName).build())
+       .addCode("%L", TypeSpec.structBuilder("TestStruct").addProperty("data", dataTypeName).build())
+       .build()
+
+    val testFile = FileSpec.builder("tesfile")
+       .addFunction(testFunc)
+       .build()
+
+    MatcherAssert.assertThat(
+       buildString { testFile.writeTo(this) },
+       CoreMatchers.equalTo(
+          """
+            import Foundation
+            
+            func test() {
+              typealias TestAlias = Data
+              struct TestStruct {
+
+                let data: Data
+
+              }
+            }
+
+          """.trimIndent()
+       )
+    )
+  }
 
   @Test
   @DisplayName("Generates 'if' control flow with indent")


### PR DESCRIPTION
Fixes and adds test for a number of things that were still using `TypeSpec` and would fail or emit incorrect code when using `TypeAliasSpec`/