### PR TITLE
Fix spacing for simple continuing control flow constructs (e.g. “else”)

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/CodeBlock.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/CodeBlock.kt
@@ -359,9 +359,13 @@ class CodeBlock private constructor(
      * @param controlFlowCode the control flow construct and its code, such as "else if (foo == 10)".
      *     Shouldn't contain braces or newline characters.
      */
-    fun nextControlFlow(controlFlowName: String, controlFlowCode: String, vararg args: Any?) = apply {
+    fun nextControlFlow(controlFlowName: String, controlFlowCode: String = "", vararg args: Any?) = apply {
       unindent()
-      add("} $controlFlowName $controlFlowCode {\n", *args)
+      if (controlFlowCode.isEmpty()) {
+        add("} $controlFlowName {\n")
+      } else {
+        add("} $controlFlowName $controlFlowCode {\n", *args)
+      }
       indent()
     }
 

--- a/src/test/java/io/outfoxx/swiftpoet/test/CodeBlockTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/CodeBlockTests.kt
@@ -128,10 +128,40 @@ class CodeBlockTests {
       out.toString(),
       equalTo(
         """
-            if x == 5 {
-              print("It's five!")
-            }
-            
+          if x == 5 {
+            print("It's five!")
+          }
+          
+        """.trimIndent()
+      )
+    )
+  }
+
+  @Test
+  @DisplayName("Generates 'else' control flow with correct spacing")
+  fun testGenElseControlFlowWithCorrectSpacing() {
+
+    val code = CodeBlock.builder()
+      .beginControlFlow("if", "x == %L", 5)
+      .addStatement("print(\"It's five!\")")
+      .nextControlFlow("else")
+      .addStatement("print(\"It's not five :(\")")
+      .endControlFlow("if")
+      .build()
+
+    val out = StringWriter()
+    CodeWriter(out).emitCode(code)
+
+    assertThat(
+      out.toString(),
+      equalTo(
+        """
+          if x == 5 {
+            print("It's five!")
+          } else {
+            print("It's not five :(")
+          }
+          
         """.trimIndent()
       )
     )


### PR DESCRIPTION
When calling `nextControlFlow` with a simple construct (e.g. `else`) there is no longer an extra space present.

Also, defaults the `controlFlowCode` argument to empty string for convenience.

Fixes #35 