### PR TITLE
Add Taggable support to all specs & builders

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/AnyTypeSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/AnyTypeSpec.kt
@@ -16,10 +16,13 @@
 
 package io.outfoxx.swiftpoet
 
+import kotlin.reflect.KClass
+
 abstract class AnyTypeSpec(
   val name: String,
-  attributes: List<AttributeSpec> = listOf()
-) : AttributedSpec(attributes.toImmutableList()) {
+  attributes: List<AttributeSpec>,
+  tags: Map<KClass<*>, Any>
+) : AttributedSpec(attributes.toImmutableList(), tags) {
 
   internal open val typeSpecs: List<AnyTypeSpec> = listOf()
 

--- a/src/main/java/io/outfoxx/swiftpoet/AttributeSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/AttributeSpec.kt
@@ -16,7 +16,10 @@
 
 package io.outfoxx.swiftpoet
 
-class AttributeSpec internal constructor(builder: Builder) {
+class AttributeSpec internal constructor(
+  builder: Builder
+) : Taggable(builder.tags.toImmutableMap()) {
+
   internal val identifier = builder.identifier
   internal val arguments = builder.arguments
 
@@ -31,7 +34,9 @@ class AttributeSpec internal constructor(builder: Builder) {
     return out
   }
 
-  class Builder internal constructor(val identifier: CodeBlock) {
+  class Builder internal constructor(
+    val identifier: CodeBlock
+  ) : Taggable.Builder<Builder>() {
     internal val arguments = mutableListOf<String>()
 
     fun addArgument(code: String): Builder = apply {

--- a/src/main/java/io/outfoxx/swiftpoet/AttributedSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/AttributedSpec.kt
@@ -16,6 +16,9 @@
 
 package io.outfoxx.swiftpoet
 
+import kotlin.reflect.KClass
+
 open class AttributedSpec(
-  val attributes: List<AttributeSpec> = listOf()
-)
+  val attributes: List<AttributeSpec>,
+  tags: Map<KClass<*>, Any>
+) : Taggable(tags.toImmutableMap())

--- a/src/main/java/io/outfoxx/swiftpoet/EnumerationCaseSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/EnumerationCaseSpec.kt
@@ -18,7 +18,7 @@ package io.outfoxx.swiftpoet
 
 class EnumerationCaseSpec private constructor(
   builder: Builder
-) : AttributedSpec(builder.attributes) {
+) : AttributedSpec(builder.attributes.toImmutableList(), builder.tags) {
 
   val name = builder.name
   val typeOrConstant = builder.typeOrConstant
@@ -47,7 +47,7 @@ class EnumerationCaseSpec private constructor(
   class Builder internal constructor(
     internal var name: String,
     internal var typeOrConstant: Any?
-  ) {
+  ) : Taggable.Builder<Builder>() {
 
     internal val attributes = mutableListOf<AttributeSpec>()
     internal val doc = CodeBlock.builder()

--- a/src/main/java/io/outfoxx/swiftpoet/ExtensionSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/ExtensionSpec.kt
@@ -19,7 +19,10 @@ package io.outfoxx.swiftpoet
 import io.outfoxx.swiftpoet.Modifier.INTERNAL
 
 /** A generated class, protocol, or enum declaration.  */
-class ExtensionSpec private constructor(builder: ExtensionSpec.Builder) {
+class ExtensionSpec private constructor(
+  builder: Builder
+) : Taggable(builder.tags.toImmutableMap()) {
+
   val doc = builder.doc.build()
   val extendedType = builder.extendedType
   val modifiers = builder.modifiers.toImmutableSet()
@@ -115,7 +118,9 @@ class ExtensionSpec private constructor(builder: ExtensionSpec.Builder) {
 
   override fun toString() = buildString { emit(CodeWriter(this)) }
 
-  class Builder internal constructor(internal val extendedType: AnyTypeSpec) {
+  class Builder internal constructor(
+    internal val extendedType: AnyTypeSpec
+  ) : Taggable.Builder<Builder>() {
     internal val doc = CodeBlock.builder()
     internal val modifiers = mutableSetOf<Modifier>()
     internal val superTypes = mutableListOf<TypeName>()

--- a/src/main/java/io/outfoxx/swiftpoet/FileMemberSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/FileMemberSpec.kt
@@ -16,7 +16,10 @@
 
 package io.outfoxx.swiftpoet
 
-class FileMemberSpec internal constructor(builder: Builder) {
+class FileMemberSpec internal constructor(
+  builder: Builder
+) : Taggable(builder.tags.toImmutableMap()) {
+
   val doc = builder.doc.build()
   val member = builder.member
   val guardTest = builder.guardTest.build()
@@ -47,7 +50,9 @@ class FileMemberSpec internal constructor(builder: Builder) {
     return out
   }
 
-  class Builder internal constructor(internal val member: Any) {
+  class Builder internal constructor(
+    internal val member: Any
+  ) : Taggable.Builder<Builder>() {
     internal val doc = CodeBlock.builder()
     internal val guardTest = CodeBlock.builder()
 

--- a/src/main/java/io/outfoxx/swiftpoet/FileSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/FileSpec.kt
@@ -34,7 +34,10 @@ import java.nio.file.Path
  * - Imports
  * - Members
  */
-class FileSpec private constructor(builder: FileSpec.Builder) {
+class FileSpec private constructor(
+  builder: Builder
+) : Taggable(builder.tags.toImmutableMap()) {
+
   val comment = builder.comment.build()
   val moduleName = builder.moduleName
   val name = builder.name
@@ -119,7 +122,7 @@ class FileSpec private constructor(builder: FileSpec.Builder) {
   class Builder internal constructor(
     val moduleName: String,
     val name: String
-  ) {
+  ) : Taggable.Builder<Builder>() {
     internal val comment = CodeBlock.builder()
     internal val moduleImports = sortedSetOf<ImportSpec>()
     internal var indent = DEFAULT_INDENT

--- a/src/main/java/io/outfoxx/swiftpoet/FunctionSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/FunctionSpec.kt
@@ -19,7 +19,8 @@ package io.outfoxx.swiftpoet
 /** A generated function declaration.  */
 class FunctionSpec private constructor(
   builder: Builder
-) : AttributedSpec(builder.attributes) {
+) : AttributedSpec(builder.attributes.toImmutableList(), builder.tags) {
+
   val name = builder.name
   val doc = builder.doc.build()
   val modifiers = builder.modifiers.toImmutableSet()
@@ -149,7 +150,9 @@ class FunctionSpec private constructor(
     return builder
   }
 
-  class Builder internal constructor(internal val name: String) {
+  class Builder internal constructor(
+    internal val name: String
+  ) : Taggable.Builder<Builder>() {
     internal val doc = CodeBlock.builder()
     internal val attributes = mutableListOf<AttributeSpec>()
     internal val modifiers = mutableListOf<Modifier>()

--- a/src/main/java/io/outfoxx/swiftpoet/ImportSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/ImportSpec.kt
@@ -17,8 +17,9 @@
 package io.outfoxx.swiftpoet
 
 class ImportSpec internal constructor(
-  builder: ImportSpec.Builder
-) : AttributedSpec(builder.attributes.toImmutableList()), Comparable<ImportSpec> {
+  builder: Builder
+) : AttributedSpec(builder.attributes.toImmutableList(), builder.tags), Comparable<ImportSpec> {
+
   val name = builder.name
   val doc = builder.doc.build()
   val guardTest = builder.guardTest.build()
@@ -52,7 +53,9 @@ class ImportSpec internal constructor(
 
   override fun compareTo(other: ImportSpec) = importString.compareTo(other.importString)
 
-  class Builder internal constructor(internal val name: String) {
+  class Builder internal constructor(
+    internal val name: String
+  ) : Taggable.Builder<Builder>() {
     internal val doc = CodeBlock.builder()
     internal val attributes = mutableListOf<AttributeSpec>()
     internal val guardTest = CodeBlock.builder()

--- a/src/main/java/io/outfoxx/swiftpoet/ParameterSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/ParameterSpec.kt
@@ -18,8 +18,9 @@ package io.outfoxx.swiftpoet
 
 /** A generated parameter declaration.  */
 class ParameterSpec private constructor(
-  builder: ParameterSpec.Builder
-) : AttributedSpec(builder.attributes) {
+  builder: Builder
+) : AttributedSpec(builder.attributes.toImmutableList(), builder.tags) {
+
   val argumentLabel = builder.argumentLabel
   val parameterName = builder.parameterName
   val modifiers = builder.modifiers.toImmutableSet()
@@ -77,7 +78,7 @@ class ParameterSpec private constructor(
     internal val argumentLabel: String?,
     internal val parameterName: String,
     internal val type: TypeName
-  ) {
+  ) : Taggable.Builder<Builder>() {
     internal val attributes = mutableListOf<AttributeSpec>()
     internal val modifiers = mutableListOf<Modifier>()
     internal var variadic = false

--- a/src/main/java/io/outfoxx/swiftpoet/PropertySpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/PropertySpec.kt
@@ -23,7 +23,8 @@ import io.outfoxx.swiftpoet.FunctionSpec.Companion.SETTER
 /** A generated property declaration.  */
 class PropertySpec private constructor(
   builder: Builder
-) : AttributedSpec(builder.attributes) {
+) : AttributedSpec(builder.attributes.toImmutableList(), builder.tags) {
+
   val mutable = builder.mutable
   val name = builder.name
   val type = builder.type
@@ -98,7 +99,10 @@ class PropertySpec private constructor(
     return builder
   }
 
-  class Builder internal constructor(internal val name: String, internal val type: TypeName) {
+  class Builder internal constructor(
+    internal val name: String,
+    internal val type: TypeName
+  ) : Taggable.Builder<Builder>() {
     internal var mutable = false
     internal val doc = CodeBlock.builder()
     internal val attributes = mutableListOf<AttributeSpec>()

--- a/src/main/java/io/outfoxx/swiftpoet/Taggable.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/Taggable.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2018 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.swiftpoet
+
+import kotlin.reflect.KClass
+
+/** A type that can be tagged with extra metadata of the user's choice. */
+abstract class Taggable(
+  /** all tags. */
+  val tags: Map<KClass<*>, Any>
+) {
+
+  /** Returns the tag attached with [type] as a key, or null if no tag is attached with that key. */
+  inline fun <reified T : Any> tag(type: KClass<T>): T? = tags[type] as T?
+
+  /** Returns the tag attached with [type] as a key, or null if no tag is attached with that key. */
+  inline fun <reified T : Any> tag(type: Class<T>): T? = tag(type.kotlin)
+
+  /** The builder analogue to [Taggable] types. */
+  abstract class Builder<out B : Builder<B>> {
+
+    /** Mutable map of the current tags this builder contains. */
+    val tags: MutableMap<KClass<*>, Any> = mutableMapOf()
+
+    /**
+     * Attaches [tag] to the request using [type] as a key. Tags can be read from a
+     * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+     * [type].
+     *
+     * Use this API to attach originating elements, debugging, or other application data to a spec
+     * so that you may read it in other APIs or callbacks.
+     */
+    fun <T : Any> tag(type: Class<T>, tag: T?): B = tag(type.kotlin, tag)
+
+    /**
+     * Attaches [tag] to the request using [type] as a key. Tags can be read from a
+     * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+     * [type].
+     *
+     * Use this API to attach originating elements, debugging, or other application data to a spec
+     * so that you may read it in other APIs or callbacks.
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun <T : Any> tag(type: KClass<T>, tag: T?): B = apply {
+      if (tag == null) {
+        this.tags.remove(type)
+      } else {
+        this.tags[type] = tag
+      }
+    } as B
+  }
+}
+
+/** Returns the tag attached with [T] as a key, or null if no tag is attached with that key. */
+inline fun <reified T : Any> Taggable.tag(): T? = tag(T::class)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+
+inline fun <reified T : Any> AttributeSpec.Builder.tag(tag: T?): AttributeSpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+
+inline fun <reified T : Any> EnumerationCaseSpec.Builder.tag(tag: T?): EnumerationCaseSpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+
+inline fun <reified T : Any> ExtensionSpec.Builder.tag(tag: T?): ExtensionSpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+
+inline fun <reified T : Any> FileMemberSpec.Builder.tag(tag: T?): FileMemberSpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+inline fun <reified T : Any> FileSpec.Builder.tag(tag: T?): FileSpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+inline fun <reified T : Any> FunctionSpec.Builder.tag(tag: T?): FunctionSpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+
+inline fun <reified T : Any> ImportSpec.Builder.tag(tag: T?): ImportSpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+inline fun <reified T : Any> ParameterSpec.Builder.tag(tag: T?): ParameterSpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+inline fun <reified T : Any> PropertySpec.Builder.tag(tag: T?): PropertySpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+inline fun <reified T : Any> TypeAliasSpec.Builder.tag(tag: T?): TypeAliasSpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+inline fun <reified T : Any> TypeSpec.Builder.tag(tag: T?): TypeSpec.Builder =
+  tag(T::class, tag)

--- a/src/main/java/io/outfoxx/swiftpoet/TypeAliasSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/TypeAliasSpec.kt
@@ -22,8 +22,8 @@ import io.outfoxx.swiftpoet.Modifier.PUBLIC
 
 /** A generated typealias declaration */
 class TypeAliasSpec private constructor(
-  builder: TypeAliasSpec.Builder
-) : AnyTypeSpec(builder.name, builder.attributes.toImmutableList()) {
+  builder: Builder
+) : AnyTypeSpec(builder.name, builder.attributes, builder.tags) {
 
   val type = builder.type
   val modifiers = builder.modifiers.toImmutableSet()
@@ -62,7 +62,7 @@ class TypeAliasSpec private constructor(
   class Builder internal constructor(
     internal val name: String,
     internal val type: TypeName
-  ) {
+  ) : Taggable.Builder<Builder>() {
     internal val doc = CodeBlock.builder()
     internal val attributes = mutableListOf<AttributeSpec>()
     internal val modifiers = mutableSetOf<Modifier>()

--- a/src/main/java/io/outfoxx/swiftpoet/TypeSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/TypeSpec.kt
@@ -20,8 +20,8 @@ import io.outfoxx.swiftpoet.Modifier.INTERNAL
 
 /** A generated class, struct, enum or protocol declaration. */
 class TypeSpec private constructor(
-  builder: TypeSpec.Builder
-) : AnyTypeSpec(builder.name, builder.attributes.toImmutableList()) {
+  builder: Builder
+) : AnyTypeSpec(builder.name, builder.attributes, builder.tags) {
 
   val kind = builder.kind
   val doc = builder.doc.build()
@@ -232,7 +232,7 @@ class TypeSpec private constructor(
   class Builder internal constructor(
     internal var kind: Kind,
     internal val name: String
-  ) {
+  ) : Taggable.Builder<Builder>() {
     internal val doc = CodeBlock.builder()
     internal val attributes = mutableListOf<AttributeSpec>()
     internal val typeVariables = mutableListOf<TypeVariableName>()


### PR DESCRIPTION
Allows tagging specs & builders with arbitrary domain specific data.

Note that this is a near exact copy of Taggable from kotlinpoet.