### PR TITLE
API fixes

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/AnyTypeSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/AnyTypeSpec.kt
@@ -24,7 +24,7 @@ abstract class AnyTypeSpec(
   tags: Map<KClass<*>, Any>
 ) : AttributedSpec(attributes.toImmutableList(), tags) {
 
-  internal open val typeSpecs: List<AnyTypeSpec> = listOf()
+  open val typeSpecs: List<AnyTypeSpec> = listOf()
 
   internal abstract fun emit(codeWriter: CodeWriter)
 }

--- a/src/main/java/io/outfoxx/swiftpoet/FileSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/FileSpec.kt
@@ -128,10 +128,6 @@ class FileSpec private constructor(
     internal var indent = DEFAULT_INDENT
     internal val members = mutableListOf<FileMemberSpec>()
 
-    init {
-      require(name.isName) { "not a valid file name: $name" }
-    }
-
     fun addComment(format: String, vararg args: Any) = apply {
       comment.add(format, *args)
     }


### PR DESCRIPTION
* Make `AnyTypeSpec.typeSpecs` public like other properties in other specs
* Remove unnecessary check if file name is the same as a keyword