### PR TITLE
Allow `DeclaredTypeName`s to always be fully qualified.

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/DeclaredTypeName.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/DeclaredTypeName.kt
@@ -18,7 +18,8 @@ package io.outfoxx.swiftpoet
 
 /** A fully-qualified type name for top-level and member types.  */
 class DeclaredTypeName internal constructor(
-  names: List<String>
+  names: List<String>,
+  val alwaysQualify: Boolean = false,
 ) : TypeName(), Comparable<DeclaredTypeName> {
 
   /**
@@ -47,9 +48,9 @@ class DeclaredTypeName internal constructor(
    * Returns the enclosing type, like [Map] for `Map.Entry`. Returns null if this type
    * is not nested in another type.
    */
-  fun enclosingTypeName(): DeclaredTypeName? {
+  fun enclosingTypeName(alwaysQualify: Boolean = this.alwaysQualify): DeclaredTypeName? {
     return if (names.size != 2)
-      DeclaredTypeName(names.subList(0, names.size - 1)) else
+      DeclaredTypeName(names.subList(0, names.size - 1), alwaysQualify) else
       null
   }
 
@@ -57,37 +58,41 @@ class DeclaredTypeName internal constructor(
    * Returns the top type in this nesting group. Equivalent to chained calls to
    * [DeclaredTypeName.enclosingTypeName] until the result's enclosing type is null.
    */
-  fun topLevelTypeName() = DeclaredTypeName(names.subList(0, 2))
+  fun topLevelTypeName(alwaysQualify: Boolean = this.alwaysQualify) =
+    DeclaredTypeName(names.subList(0, 2), alwaysQualify)
 
   /**
    * Returns a new [DeclaredTypeName] instance for the specified `name` as nested inside this
    * type.
    */
-  fun nestedType(name: String) = DeclaredTypeName(names + name)
+  fun nestedType(name: String, alwaysQualify: Boolean = this.alwaysQualify) =
+    DeclaredTypeName(names + name, alwaysQualify)
 
   /**
    * Returns a type that shares the same enclosing package or type. If this type is enclosed by
    * another type, this is equivalent to `enclosingTypeName().nestedType(name)`. Otherwise
    * it is equivalent to `get(packageName(), name)`.
    */
-  fun peerType(name: String): DeclaredTypeName {
+  fun peerType(name: String, alwaysQualify: Boolean = this.alwaysQualify): DeclaredTypeName {
     val result = names.toMutableList()
     result[result.size - 1] = name
-    return DeclaredTypeName(result)
+    return DeclaredTypeName(result, alwaysQualify)
   }
 
   override fun compareTo(other: DeclaredTypeName) = canonicalName.compareTo(other.canonicalName)
 
-  override fun emit(out: CodeWriter) = out.emit(escapeKeywords(out.lookupName(this)))
+  override fun emit(out: CodeWriter) =
+    out.emit(escapeKeywords(if (alwaysQualify) canonicalName else out.lookupName(this)))
 
   companion object {
-    @JvmStatic fun typeName(qualifiedTypeName: String): DeclaredTypeName {
+    @JvmStatic fun typeName(qualifiedTypeName: String, alwaysQualify: Boolean = false): DeclaredTypeName {
       val names = qualifiedTypeName.split('.')
       if (names.size < 2) {
         throw IllegalArgumentException("Type names MUST be qualified with their module name; to create a type for the 'current' module start the type with a '.' (e.g. '.MyType')")
       }
-      return DeclaredTypeName(qualifiedTypeName.split('.'))
+      return DeclaredTypeName(qualifiedTypeName.split('.'), alwaysQualify)
     }
+    @JvmStatic fun qualifiedTypeName(qualifiedTypeName: String) = typeName(qualifiedTypeName, alwaysQualify = true)
   }
 }
 

--- a/src/test/java/io/outfoxx/swiftpoet/test/FileSpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/FileSpecTests.kt
@@ -18,6 +18,7 @@ package io.outfoxx.swiftpoet.test
 
 import io.outfoxx.swiftpoet.ComposedTypeName.Companion.composed
 import io.outfoxx.swiftpoet.DATA
+import io.outfoxx.swiftpoet.DeclaredTypeName.Companion.qualifiedTypeName
 import io.outfoxx.swiftpoet.DeclaredTypeName.Companion.typeName
 import io.outfoxx.swiftpoet.ExtensionSpec
 import io.outfoxx.swiftpoet.FileMemberSpec
@@ -48,6 +49,32 @@ class FileSpecTests {
 
     assertThat(testFileBuilder.tags[Integer::class] as? Int, equalTo(5))
     assertThat(testFile.tag(), equalTo(5))
+  }
+
+  @Test
+  @DisplayName("Generates fully qualified types for 'alwaysQualify' declared types")
+  fun testDeclaredAlwaysQualified() {
+
+    val explicitType = qualifiedTypeName("Special.Array")
+
+    val testFile = FileSpec.builder("Test", "Test")
+      .addProperty(
+        PropertySpec.builder("value", explicitType)
+          .build()
+      )
+      .build()
+
+    val out = StringWriter()
+    testFile.writeTo(out)
+
+    assertThat(
+      out.toString(),
+      equalTo(
+        """
+            let value: Special.Array
+        """.trimIndent()
+      )
+    )
   }
 
   @Test


### PR DESCRIPTION
Using `TypeName.qualifiedTypeName(String)` will produce a type name that is always qualified and will never produce an import statement.
