### PR TITLE
Fix nested protocol rules

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/TypeSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/TypeSpec.kt
@@ -350,7 +350,7 @@ class TypeSpec private constructor(
 
     fun addType(typeSpec: AnyTypeSpec) = apply {
       check(!isProtocol || typeSpec is TypeAliasSpec) {
-        "${this.name} is a protocol, it can only contain typealias as nested types"
+        "${this.name} is a protocol, it can only contain type aliases as nested types"
       }
       check(!(typeSpec is TypeSpec && typeSpec.kind is Kind.Protocol)) {
         "${typeSpec.name} is a protocol, it cannot be added as a nested type"

--- a/src/main/java/io/outfoxx/swiftpoet/TypeSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/TypeSpec.kt
@@ -23,7 +23,7 @@ class TypeSpec private constructor(
   builder: Builder
 ) : AnyTypeSpec(builder.name, builder.attributes, builder.tags) {
 
-  val kind = builder.kind
+  internal val kind = builder.kind
   val doc = builder.doc.build()
   val modifiers = kind.modifiers.toImmutableSet()
   val typeVariables = builder.typeVariables.toImmutableList()
@@ -345,12 +345,16 @@ class TypeSpec private constructor(
     }
 
     fun addTypes(typeSpecs: Iterable<AnyTypeSpec>) = apply {
-      check(!isProtocol) { "${this.name} is a protocol, it cannot contain nested types" }
-      this.typeSpecs += typeSpecs
+      typeSpecs.forEach(::addType)
     }
 
     fun addType(typeSpec: AnyTypeSpec) = apply {
-      check(!isProtocol) { "${this.name} is a protocol, it cannot contain nested types" }
+      check(!isProtocol || typeSpec is TypeAliasSpec) {
+        "${this.name} is a protocol, it can only contain typealias as nested types"
+      }
+      check(!(typeSpec is TypeSpec && typeSpec.kind is Kind.Protocol)) {
+        "${typeSpec.name} is a protocol, it cannot be added as a nested type"
+      }
       typeSpecs += typeSpec
     }
 

--- a/src/test/java/io/outfoxx/swiftpoet/test/ProtocolSpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/ProtocolSpecTests.kt
@@ -361,21 +361,23 @@ class ProtocolSpecTests {
   @Test
   @DisplayName("Protocols cannot contain nested types")
   fun testAddNestedTypeToProtocol() {
-    assertThrows<IllegalStateException> {
+    val exception = assertThrows<IllegalStateException> {
       TypeSpec.protocolBuilder("Test")
         .addType(TypeSpec.protocolBuilder("Nested").build())
         .build()
     }
+    assertThat(exception.message, equalTo("Test is a protocol, it can only contain type aliases as nested types"))
   }
 
   @Test
   @DisplayName("Protocols cannot be added as nested types")
   fun testAddProtocolAsNestedType() {
-    assertThrows<IllegalStateException> {
+    val exception = assertThrows<IllegalStateException> {
       TypeSpec.structBuilder("Test")
         .addType(TypeSpec.protocolBuilder("Nested").build())
         .build()
     }
+    assertThat(exception.message, equalTo("Nested is a protocol, it cannot be added as a nested type"))
   }
 
   @Test

--- a/src/test/java/io/outfoxx/swiftpoet/test/ProtocolSpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/ProtocolSpecTests.kt
@@ -16,13 +16,22 @@
 
 package io.outfoxx.swiftpoet.test
 
-import io.outfoxx.swiftpoet.*
 import io.outfoxx.swiftpoet.AttributeSpec.Companion.available
+import io.outfoxx.swiftpoet.CodeWriter
 import io.outfoxx.swiftpoet.ComposedTypeName.Companion.composed
 import io.outfoxx.swiftpoet.DeclaredTypeName.Companion.typeName
 import io.outfoxx.swiftpoet.FunctionSpec.Companion.abstractBuilder
+import io.outfoxx.swiftpoet.INT
+import io.outfoxx.swiftpoet.Modifier
+import io.outfoxx.swiftpoet.PropertySpec
+import io.outfoxx.swiftpoet.STRING
+import io.outfoxx.swiftpoet.TypeAliasSpec
+import io.outfoxx.swiftpoet.TypeName
+import io.outfoxx.swiftpoet.TypeSpec
 import io.outfoxx.swiftpoet.TypeVariableName.Companion.bound
 import io.outfoxx.swiftpoet.TypeVariableName.Companion.typeVariable
+import io.outfoxx.swiftpoet.tag
+import io.outfoxx.swiftpoet.toImmutableSet
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.hasItems
 import org.hamcrest.MatcherAssert.assertThat
@@ -351,7 +360,7 @@ class ProtocolSpecTests {
 
   @Test
   @DisplayName("Protocols cannot contain nested types")
-  fun testAddNestedTypeTo() {
+  fun testAddNestedTypeToProtocol() {
     assertThrows<IllegalStateException> {
       TypeSpec.protocolBuilder("Test")
         .addType(TypeSpec.protocolBuilder("Nested").build())


### PR DESCRIPTION
As reported on issue #60, the current implementation of the nested protocol rules doesn't account for a couple of scenarios where either the input is allowed but not supported by SwiftPoet, or the output of SwiftPoet is invalid Swift code.

This PR fixes both scenarios:

- it allows protocols to have `TypeAliasSpec` as a nested type
- it doesn't allow protocol to be added as a nested type of any construct

Tests were added for both scenarios.