### PR TITLE
Fix issue emitting simple type declarations with no bounds

### DIFF
--- a/src/test/java/io/outfoxx/swiftpoet/test/ActorSpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/ActorSpecTests.kt
@@ -271,6 +271,30 @@ class ActorSpecTests {
   }
 
   @Test
+  @DisplayName("Generates type variables (boundless)")
+  fun testGenTypeVarsBoundless() {
+    val testClass = TypeSpec.actorBuilder("Test")
+      .addTypeVariable(
+        TypeVariableName.typeVariable("X")
+      )
+      .build()
+
+    val out = StringWriter()
+    testClass.emit(CodeWriter(out))
+
+    assertThat(
+      out.toString(),
+      equalTo(
+        """
+            actor Test<X> {
+            }
+
+        """.trimIndent()
+      )
+    )
+  }
+
+  @Test
   @DisplayName("Generates super types")
   fun testGenSuperActor() {
     val testActor = TypeSpec.actorBuilder("Test")

--- a/src/test/java/io/outfoxx/swiftpoet/test/ClassSpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/ClassSpecTests.kt
@@ -271,6 +271,30 @@ class ClassSpecTests {
   }
 
   @Test
+  @DisplayName("Generates type variables (boundless)")
+  fun testGenTypeVarsBoundless() {
+    val testClass = TypeSpec.classBuilder("Test")
+      .addTypeVariable(
+        TypeVariableName.typeVariable("X")
+      )
+      .build()
+
+    val out = StringWriter()
+    testClass.emit(CodeWriter(out))
+
+    assertThat(
+      out.toString(),
+      equalTo(
+        """
+            class Test<X> {
+            }
+
+        """.trimIndent()
+      )
+    )
+  }
+
+  @Test
   @DisplayName("Generates super types")
   fun testGenSuperClass() {
     val testClass = TypeSpec.classBuilder("Test")


### PR DESCRIPTION
Emitting type variables with no bound clauses was regressed in 1.4.1 due to missing tests.