### PR TITLE
Ignore argumentLabel when equal to parameterName

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/ParameterSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/ParameterSpec.kt
@@ -30,7 +30,11 @@ class ParameterSpec private constructor(
 
   internal fun emit(codeWriter: CodeWriter, includeType: Boolean = true, includeNames: Boolean = true) {
     if (includeNames) {
-      argumentLabel?.let { codeWriter.emitCode("%L ", escapeIfNecessary(it)) }
+      argumentLabel?.let { argLabel ->
+        if (argLabel != parameterName) {
+          codeWriter.emitCode("%L ", escapeIfNecessary(argLabel))
+        }
+      }
       codeWriter.emitCode("%L", escapeIfNecessary(parameterName))
     }
     if (includeType) {

--- a/src/test/java/io/outfoxx/swiftpoet/test/FunctionSpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/FunctionSpecTests.kt
@@ -585,6 +585,28 @@ class FunctionSpecTests {
   }
 
   @Test
+  @DisplayName("Ignores duplicate parameter name")
+  fun testGenParameterIgnoresDuplicateName() {
+    val testClass = FunctionSpec.builder("test")
+      .addParameter("parameter", "parameter", STRING)
+      .build()
+
+    val out = StringWriter()
+    testClass.emit(CodeWriter(out), null, setOf())
+
+    assertThat(
+      out.toString(),
+      equalTo(
+        """
+            func test(parameter: Swift.String) {
+            }
+
+        """.trimIndent()
+      )
+    )
+  }
+
+  @Test
   @DisplayName("toBuilder copies all fields")
   fun testToBuilder() {
     val testFuncBlder = FunctionSpec.builder("Test")


### PR DESCRIPTION
Declaring a function parameter with the same value for
argumentLabel and parameterSpec produces a warning in xcode (often
treated as error if the compiler setting is enabled). We should handle
this while emitting code and only adding the argumentLabel when its
value is different from parameterName

<img width="1731" alt="Screenshot 2022-07-18 at 10 07 02" src="https://user-images.githubusercontent.com/244899/179470362-c0bf2dba-c1eb-43f6-9b45-3c6fc756a027.png">

