### PR TITLE
Add support for subscript properties

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/ExtensionSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/ExtensionSpec.kt
@@ -92,14 +92,14 @@ class ExtensionSpec private constructor(
       for (funSpec in funSpecs) {
         if (!funSpec.isConstructor) continue
         codeWriter.emit("\n")
-        funSpec.emit(codeWriter, typeName, setOf(INTERNAL))
+        funSpec.emit(codeWriter, setOf(INTERNAL))
       }
 
       // Functions.
       for (funSpec in funSpecs) {
         if (funSpec.isConstructor) continue
         codeWriter.emit("\n")
-        funSpec.emit(codeWriter, typeName, setOf(INTERNAL))
+        funSpec.emit(codeWriter, setOf(INTERNAL))
       }
 
       codeWriter.unindent()

--- a/src/main/java/io/outfoxx/swiftpoet/FileMemberSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/FileMemberSpec.kt
@@ -36,7 +36,7 @@ class FileMemberSpec internal constructor(
 
     when (member) {
       is AnyTypeSpec -> member.emit(out)
-      is FunctionSpec -> member.emit(out, null, setOf(Modifier.INTERNAL))
+      is FunctionSpec -> member.emit(out, setOf(Modifier.INTERNAL))
       is PropertySpec -> member.emit(out, setOf(Modifier.INTERNAL))
       is ExtensionSpec -> member.emit(out)
       else -> throw AssertionError()

--- a/src/main/java/io/outfoxx/swiftpoet/FunctionSignatureSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/FunctionSignatureSpec.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2018 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.swiftpoet
+
+class FunctionSignatureSpec(builder: Builder) {
+
+  val typeVariables = builder.typeVariables.toImmutableList()
+  val returnType = builder.returnType
+  val parameters = builder.parameters.toImmutableList()
+  val throws = builder.throws
+  val async = builder.async
+  val failable = builder.failable
+
+  internal fun emit(codeWriter: CodeWriter, name: String, includeEmptyParameters: Boolean = true) {
+    codeWriter.emit(name)
+    if (failable) {
+      codeWriter.emit("?")
+    }
+
+    if (typeVariables.isNotEmpty()) {
+      codeWriter.emitTypeVariables(typeVariables)
+    }
+
+    if (parameters.isNotEmpty() || includeEmptyParameters) {
+      parameters.emit(codeWriter) { param ->
+        param.emit(codeWriter, includeType = name != FunctionSpec.SETTER)
+      }
+    }
+
+    val modifiers = mutableListOf<String>()
+
+    if (async) {
+      modifiers.add("async")
+    }
+    if (throws) {
+      modifiers.add("throws")
+    }
+
+    if (modifiers.isNotEmpty()) {
+      codeWriter.emit(modifiers.joinToString(separator = " ", prefix = " "))
+    }
+
+    if (returnType != null && returnType != VOID) {
+      codeWriter.emitCode(" -> %T", returnType)
+    }
+
+    codeWriter.emitWhereBlock(typeVariables)
+  }
+
+  class Builder internal constructor() : AttributedSpec.Builder<Builder>() {
+    internal val typeVariables = mutableListOf<TypeVariableName>()
+    internal var returnType: TypeName? = null
+    internal val parameters = mutableListOf<ParameterSpec>()
+    internal var throws = false
+    internal var async = false
+    internal var failable = false
+    internal val body: CodeBlock.Builder = CodeBlock.builder()
+
+    fun addTypeVariables(typeVariables: Iterable<TypeVariableName>) = apply {
+      this.typeVariables += typeVariables
+    }
+
+    fun addTypeVariable(typeVariable: TypeVariableName) = apply {
+      typeVariables += typeVariable
+    }
+
+    fun returns(returnType: TypeName) = apply {
+      this.returnType = returnType
+    }
+
+    fun addParameters(parameterSpecs: Iterable<ParameterSpec>) = apply {
+      for (parameterSpec in parameterSpecs) {
+        addParameter(parameterSpec)
+      }
+    }
+
+    fun addParameter(parameterSpec: ParameterSpec) = apply {
+      parameters += parameterSpec
+    }
+
+    fun addParameter(name: String, type: TypeName, vararg modifiers: Modifier) =
+      addParameter(ParameterSpec.builder(name, type, *modifiers).build())
+
+    fun addParameter(label: String, name: String, type: TypeName, vararg modifiers: Modifier) =
+      addParameter(ParameterSpec.builder(label, name, type, *modifiers).build())
+
+    fun addCode(format: String, vararg args: Any) = apply {
+      body.add(format, *args)
+    }
+
+    fun failable(value: Boolean) = apply {
+      failable = value
+    }
+
+    fun throws(value: Boolean) = apply {
+      throws = value
+    }
+
+    fun async(value: Boolean) = apply {
+      async = value
+    }
+
+    fun build() = FunctionSignatureSpec(this)
+  }
+
+  fun toBuilder(): Builder {
+    val builder = Builder()
+    builder.typeVariables += typeVariables
+    builder.returnType = returnType
+    builder.parameters += parameters
+    builder.throws = throws
+    builder.async = async
+    builder.failable = failable
+    return builder
+  }
+
+  companion object {
+
+    @JvmStatic
+    fun builder() = Builder()
+  }
+}

--- a/src/main/java/io/outfoxx/swiftpoet/TypeSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/TypeSpec.kt
@@ -120,7 +120,7 @@ class TypeSpec private constructor(
         firstMember = false
         constructors.forEachIndexed { index, funSpec ->
           codeWriter.emit("\n")
-          funSpec.emit(codeWriter, name, kind.implicitFunctionModifiers)
+          funSpec.emit(codeWriter, kind.implicitFunctionModifiers)
           if (index == constructors.size - 1 && funSpec.body === CodeBlock.ABSTRACT) codeWriter.emit("\n")
         }
       }
@@ -131,7 +131,7 @@ class TypeSpec private constructor(
         firstMember = false
         functions.forEachIndexed { index, funSpec ->
           codeWriter.emit("\n")
-          funSpec.emit(codeWriter, name, kind.implicitFunctionModifiers)
+          funSpec.emit(codeWriter, kind.implicitFunctionModifiers)
           if (index == functions.size - 1 && funSpec.body === CodeBlock.ABSTRACT) codeWriter.emit("\n")
         }
       }

--- a/src/test/java/io/outfoxx/swiftpoet/test/FunctionSpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/FunctionSpecTests.kt
@@ -57,7 +57,7 @@ class FunctionSpecTests {
         .build()
 
     val out = StringWriter()
-    testFunc.emit(CodeWriter(out), null, setOf())
+    testFunc.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -80,7 +80,7 @@ class FunctionSpecTests {
         .build()
 
     val out = StringWriter()
-    testFunc.emit(CodeWriter(out), null, setOf())
+    testFunc.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -104,7 +104,7 @@ class FunctionSpecTests {
         .build()
 
     val out = StringWriter()
-    testFunc.emit(CodeWriter(out), null, setOf())
+    testFunc.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -131,7 +131,7 @@ class FunctionSpecTests {
         .build()
 
     val out = StringWriter()
-    testFunc.emit(CodeWriter(out), null, setOf())
+    testFunc.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -159,7 +159,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testFunc.emit(CodeWriter(out), null, setOf())
+    testFunc.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -187,7 +187,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testFunc.emit(CodeWriter(out), null, setOf())
+    testFunc.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -215,7 +215,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testFunc.emit(CodeWriter(out), null, setOf())
+    testFunc.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -242,7 +242,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testFunc.emit(CodeWriter(out), null, setOf())
+    testFunc.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -269,7 +269,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testFunc.emit(CodeWriter(out), null, setOf())
+    testFunc.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -297,7 +297,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testFunc.emit(CodeWriter(out), null, setOf())
+    testFunc.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -325,7 +325,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testFunc.emit(CodeWriter(out), null, setOf())
+    testFunc.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -353,7 +353,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testFunc.emit(CodeWriter(out), null, setOf())
+    testFunc.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -387,7 +387,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testFunc.emit(CodeWriter(out), null, setOf())
+    testFunc.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -413,7 +413,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testFunc.emit(CodeWriter(out), null, setOf())
+    testFunc.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -438,7 +438,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testFunc.emit(CodeWriter(out), null, setOf())
+    testFunc.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -462,7 +462,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testClass.emit(CodeWriter(out), null, setOf())
+    testClass.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -489,7 +489,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testClass.emit(CodeWriter(out), null, setOf())
+    testClass.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -519,7 +519,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testFunc.emit(CodeWriter(out), null, setOf())
+    testFunc.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -543,7 +543,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testFunc.emit(CodeWriter(out), null, setOf())
+    testFunc.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -570,7 +570,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testClass.emit(CodeWriter(out), null, setOf())
+    testClass.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -592,7 +592,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testClass.emit(CodeWriter(out), null, setOf())
+    testClass.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -614,7 +614,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testClass.emit(CodeWriter(out), null, setOf())
+    testClass.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -635,7 +635,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testClass.emit(CodeWriter(out), null, setOf())
+    testClass.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -657,7 +657,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testClass.emit(CodeWriter(out), null, setOf())
+    testClass.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -684,7 +684,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testClass.emit(CodeWriter(out), null, setOf())
+    testClass.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -710,7 +710,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testClass.emit(CodeWriter(out), null, setOf())
+    testClass.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -736,7 +736,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testClass.emit(CodeWriter(out), null, setOf())
+    testClass.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -758,7 +758,7 @@ class FunctionSpecTests {
       .build()
 
     val out = StringWriter()
-    testClass.emit(CodeWriter(out), null, setOf())
+    testClass.emit(CodeWriter(out), setOf())
 
     assertThat(
       out.toString(),
@@ -791,9 +791,9 @@ class FunctionSpecTests {
     assertThat(testFuncBlder.doc.formatParts, hasItems("this is a comment\n"))
     assertThat(testFuncBlder.attributes, hasItems(DISCARDABLE_RESULT))
     assertThat(testFuncBlder.modifiers.toImmutableSet(), equalTo(setOf(Modifier.PUBLIC)))
-    assertThat(testFuncBlder.typeVariables, hasItems(typeVariable("X", bound(".Test2"))))
-    assertThat(testFuncBlder.returnType, equalTo<TypeName>(STRING))
-    assertThat(testFuncBlder.parameters, hasItems(ParameterSpec.builder("a", STRING).build()))
+    assertThat(testFuncBlder.signature.typeVariables, hasItems(typeVariable("X", bound(".Test2"))))
+    assertThat(testFuncBlder.signature.returnType, equalTo<TypeName>(STRING))
+    assertThat(testFuncBlder.signature.parameters, hasItems(ParameterSpec.builder("a", STRING).build()))
     assertThat(testFuncBlder.body.formatParts, hasItems("val;\n"))
   }
 }

--- a/src/test/java/io/outfoxx/swiftpoet/test/PropertySpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/PropertySpecTests.kt
@@ -18,10 +18,17 @@ package io.outfoxx.swiftpoet.test
 
 import io.outfoxx.swiftpoet.CodeWriter
 import io.outfoxx.swiftpoet.DeclaredTypeName
+import io.outfoxx.swiftpoet.DeclaredTypeName.Companion.typeName
+import io.outfoxx.swiftpoet.FunctionSignatureSpec
+import io.outfoxx.swiftpoet.FunctionSpec
+import io.outfoxx.swiftpoet.INT
 import io.outfoxx.swiftpoet.Modifier.UNOWNED
 import io.outfoxx.swiftpoet.Modifier.WEAK
 import io.outfoxx.swiftpoet.PropertySpec
 import io.outfoxx.swiftpoet.STRING
+import io.outfoxx.swiftpoet.TypeVariableName
+import io.outfoxx.swiftpoet.TypeVariableName.Companion.typeVariable
+import io.outfoxx.swiftpoet.parameterizedBy
 import io.outfoxx.swiftpoet.tag
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -92,6 +99,137 @@ class PropertySpecTests {
       equalTo(
         """
           unowned var test: Swift.String
+        """.trimIndent()
+      )
+    )
+  }
+
+  @Test
+  @DisplayName("Generates simple subscript properties")
+  fun subscriptSimple() {
+    val subscriptProperty =
+      PropertySpec
+        .subscriptBuilder(
+          FunctionSignatureSpec.builder()
+            .addParameter("index", INT)
+            .returns(STRING)
+            .build()
+        )
+        .getter(
+          FunctionSpec
+            .getterBuilder()
+            .addStatement("%S", 1)
+            .build()
+        )
+        .setter(
+          FunctionSpec
+            .setterBuilder()
+            .addCode("")
+            .build()
+        )
+        .build()
+
+    assertThat(
+      subscriptProperty.toString(),
+      equalTo(
+        """
+          subscript(index: Swift.Int) -> Swift.String {
+            get {
+              "1"
+            }
+            set {
+            }
+          }
+        """.trimIndent()
+      )
+    )
+  }
+
+  @Test
+  @DisplayName("Generates generic subscript properties")
+  fun subscriptGeneric() {
+    val subscriptProperty =
+      PropertySpec
+        .subscriptBuilder(
+          FunctionSignatureSpec.builder()
+            .addTypeVariable(typeVariable("A"))
+            .addParameter("index", typeVariable("A"))
+            .returns(STRING)
+            .build()
+        )
+        .getter(
+          FunctionSpec
+            .getterBuilder()
+            .addStatement("%S", 1)
+            .build()
+        )
+        .setter(
+          FunctionSpec
+            .setterBuilder()
+            .addCode("")
+            .build()
+        )
+        .build()
+
+    assertThat(
+      subscriptProperty.toString(),
+      equalTo(
+        """
+          subscript<A>(index: A) -> Swift.String {
+            get {
+              "1"
+            }
+            set {
+            }
+          }
+        """.trimIndent()
+      )
+    )
+  }
+
+  @Test
+  @DisplayName("Generates keypath subscript properties")
+  fun subscriptKeypath() {
+    val subscriptProperty =
+      PropertySpec
+        .subscriptBuilder(
+          FunctionSignatureSpec.builder()
+            .addTypeVariable(typeVariable("P").withBounds(TypeVariableName.Bound(typeName("Swift.StringProtocol"))))
+            .addParameter(
+              "index",
+              typeName("Swift.KeyPath")
+                .parameterizedBy(typeName(".BackingData"), typeVariable("P"))
+            )
+            .returns(typeVariable("P"))
+            .build()
+        )
+        .getter(
+          FunctionSpec
+            .getterBuilder()
+            .addStatement("%S", 1)
+            .build()
+        )
+        .setter(
+          FunctionSpec
+            .setterBuilder()
+            .addCode("")
+            .build()
+        )
+        .build()
+
+    println(subscriptProperty)
+
+    assertThat(
+      subscriptProperty.toString(),
+      equalTo(
+        """
+          subscript<P : Swift.StringProtocol>(index: Swift.KeyPath<BackingData, P>) -> P {
+            get {
+              "1"
+            }
+            set {
+            }
+          }
         """.trimIndent()
       )
     )


### PR DESCRIPTION
* Adds new `FunctionSignatureSpec` shared between properties and functions
* subscript properties are built using a new `subscriptBuilder(FunctionSignatureSpec)` factory

Fixes #69