### PR TITLE
Support adding visibility to mutable property fields

### DIFF
--- a/src/test/java/io/outfoxx/swiftpoet/test/PropertySpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/PropertySpecTests.kt
@@ -22,6 +22,8 @@ import io.outfoxx.swiftpoet.DeclaredTypeName.Companion.typeName
 import io.outfoxx.swiftpoet.FunctionSignatureSpec
 import io.outfoxx.swiftpoet.FunctionSpec
 import io.outfoxx.swiftpoet.INT
+import io.outfoxx.swiftpoet.Modifier.PRIVATE
+import io.outfoxx.swiftpoet.Modifier.PUBLIC
 import io.outfoxx.swiftpoet.Modifier.UNOWNED
 import io.outfoxx.swiftpoet.Modifier.WEAK
 import io.outfoxx.swiftpoet.PropertySpec
@@ -99,6 +101,48 @@ class PropertySpecTests {
       equalTo(
         """
           unowned var test: Swift.String
+        """.trimIndent()
+      )
+    )
+  }
+
+  @Test
+  @DisplayName("Adds mutable visibility modifier")
+  fun addsMutableVisibility() {
+    val testProperty =
+      PropertySpec.varBuilder("test", STRING, PUBLIC)
+        .mutableVisibility(PRIVATE)
+        .build()
+
+    val out = StringWriter()
+    testProperty.emit(CodeWriter(out), setOf())
+
+    assertThat(
+      out.toString(),
+      equalTo(
+        """
+          public private(set) var test: Swift.String
+        """.trimIndent()
+      )
+    )
+  }
+
+  @Test
+  @DisplayName("Standalone mutable visibility modifier")
+  fun standaloneMutableVisibility() {
+    val testProperty =
+      PropertySpec.varBuilder("test", STRING)
+        .mutableVisibility(PRIVATE)
+        .build()
+
+    val out = StringWriter()
+    testProperty.emit(CodeWriter(out), setOf())
+
+    assertThat(
+      out.toString(),
+      equalTo(
+        """
+          private(set) var test: Swift.String
         """.trimIndent()
       )
     )


### PR DESCRIPTION
Allows generating property fields with different explicit visibility for setters.

public & private setter
```swift
public private(set) var x: Int
```

standalone private setter
```swift
private(set) var x: Int
```