### PR TITLE
Fix generation functions with 'set' and 'get' names

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/FunctionSignatureSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/FunctionSignatureSpec.kt
@@ -16,7 +16,6 @@
 
 package io.outfoxx.swiftpoet
 
-import io.outfoxx.swiftpoet.FunctionSpec.Companion.isAccessor
 import io.outfoxx.swiftpoet.FunctionSpec.Companion.isObserver
 
 class FunctionSignatureSpec(builder: Builder) {
@@ -28,7 +27,7 @@ class FunctionSignatureSpec(builder: Builder) {
   val async = builder.async
   val failable = builder.failable
 
-  internal fun emit(codeWriter: CodeWriter, name: String, includeEmptyParameters: Boolean = true) {
+  internal fun emit(codeWriter: CodeWriter, name: String, isAccessor: Boolean, includeEmptyParameters: Boolean = true) {
     codeWriter.emit(name)
     if (failable) {
       codeWriter.emit("?")
@@ -40,7 +39,7 @@ class FunctionSignatureSpec(builder: Builder) {
 
     if (parameters.isNotEmpty() || includeEmptyParameters) {
       parameters.emit(codeWriter) { param ->
-        param.emit(codeWriter, includeType = !name.isAccessor && !name.isObserver)
+        param.emit(codeWriter, includeType = !isAccessor && !name.isObserver)
       }
     }
 

--- a/src/main/java/io/outfoxx/swiftpoet/FunctionSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/FunctionSpec.kt
@@ -67,7 +67,12 @@ class FunctionSpec private constructor(
         name.removePrefix(OPERATOR)
       else
         escapeIfNecessary(name)
-    signature.emit(codeWriter, name, includeEmptyParameters = !isDeinitializer && !isAccessor && !isObserver)
+    signature.emit(
+      codeWriter = codeWriter,
+      name = name,
+      isAccessor = isAccessor,
+      includeEmptyParameters = !isDeinitializer && !isAccessor && !isObserver
+    )
 
     if (body !== CodeBlock.ABSTRACT) {
       codeWriter.emit(" {\n")
@@ -96,7 +101,7 @@ class FunctionSpec private constructor(
 
   val isDeinitializer get() = name.isDeinitializer
 
-  val isAccessor get() = name.isAccessor
+  val isAccessor = builder.isAccessor
 
   val isObserver get() = name.isObserver
 
@@ -132,6 +137,11 @@ class FunctionSpec private constructor(
     internal val localTypeSpecs = mutableListOf<AnyTypeSpec>()
     internal val body: CodeBlock.Builder = CodeBlock.builder()
     internal var abstract = false
+    internal var isAccessor = false
+
+    internal fun accessor() = apply {
+      isAccessor = true
+    }
 
     fun addDoc(format: String, vararg args: Any) = apply {
       doc.add(format, *args)
@@ -281,9 +291,9 @@ class FunctionSpec private constructor(
 
     @JvmStatic fun deinitializerBuilder() = Builder(DEINITIALIZER)
 
-    @JvmStatic fun getterBuilder() = Builder(GETTER)
+    @JvmStatic fun getterBuilder() = Builder(GETTER).accessor()
 
-    @JvmStatic fun setterBuilder() = Builder(SETTER)
+    @JvmStatic fun setterBuilder() = Builder(SETTER).accessor()
 
     @JvmStatic fun willSetBuilder() = Builder(WILL_SET)
 

--- a/src/main/java/io/outfoxx/swiftpoet/PropertySpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/PropertySpec.kt
@@ -63,7 +63,7 @@ class PropertySpec private constructor(
     codeWriter.emitModifiers(modifiers, implicitModifiers)
 
     if (subscriptSpec != null) {
-      subscriptSpec.emit(codeWriter, "subscript")
+      subscriptSpec.emit(codeWriter, "subscript", isAccessor = false)
     } else if (simpleSpec != null) {
 
       if (mutable && mutableVisibility != null) {

--- a/src/test/java/io/outfoxx/swiftpoet/test/FunctionSpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/FunctionSpecTests.kt
@@ -27,6 +27,7 @@ import io.outfoxx.swiftpoet.FunctionTypeName
 import io.outfoxx.swiftpoet.INT
 import io.outfoxx.swiftpoet.Modifier
 import io.outfoxx.swiftpoet.ParameterSpec
+import io.outfoxx.swiftpoet.PropertySpec
 import io.outfoxx.swiftpoet.STRING
 import io.outfoxx.swiftpoet.SelfTypeName
 import io.outfoxx.swiftpoet.TypeAliasSpec
@@ -795,5 +796,49 @@ class FunctionSpecTests {
     assertThat(testFuncBlder.signature.returnType, equalTo<TypeName>(STRING))
     assertThat(testFuncBlder.signature.parameters, hasItems(ParameterSpec.builder("a", STRING).build()))
     assertThat(testFuncBlder.body.formatParts, hasItems("val;\n"))
+  }
+
+  @Test
+  @DisplayName("Generate property with setter and getter")
+  fun testGenAccessors() {
+    val propertySpec = PropertySpec.builder("property", STRING)
+      .setter(
+        FunctionSpec.setterBuilder()
+          .addParameter("newValue", STRING)
+          .addCode("// This is setter\n")
+          .build()
+      )
+      .getter(
+        FunctionSpec.getterBuilder()
+          .addCode("// This is getter\n")
+          .build()
+      )
+      .build()
+
+    assertThat(
+      propertySpec.toString(),
+      equalTo(
+        """
+        var property: Swift.String {
+          get {
+            // This is getter
+          }
+          set(newValue) {
+            // This is setter
+          }
+        }
+        """.trimIndent()
+      )
+    )
+  }
+
+  @Test
+  @DisplayName("Generate function with 'set' name")
+  fun testGenSetFunction() {
+    val functionSpec = FunctionSpec.abstractBuilder("set")
+      .addParameter("property", STRING)
+      .build()
+
+    assertThat(functionSpec.toString(), equalTo("func set(property: Swift.String)"))
   }
 }


### PR DESCRIPTION
The original problem was that `FunctionSpecTests.testGenSetFunction()` test was failed.

It means you can't generate such code: `func set(property: Swift.String)` with swift poet. Instead of this you will get `set(property)` as result.

This PR fix this issue.