### PR TITLE
Fix incorrect importing of local types

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/CodeWriter.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/CodeWriter.kt
@@ -271,6 +271,9 @@ internal class CodeWriter(
   }
 
   private fun referenceTypeName(typeName: DeclaredTypeName) {
+    if (typeName.moduleName.isEmpty()) {
+      return
+    }
     referencedTypes[typeName.canonicalName] = typeName
   }
 

--- a/src/main/java/io/outfoxx/swiftpoet/ImportSpec.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/ImportSpec.kt
@@ -59,6 +59,10 @@ class ImportSpec internal constructor(
     internal val doc = CodeBlock.builder()
     internal val guardTest = CodeBlock.builder()
 
+    init {
+      require(name.isNotBlank()) { "name is empty" }
+    }
+
     fun addDoc(format: String, vararg args: Any) = apply {
       doc.add(format, *args)
     }

--- a/src/test/java/io/outfoxx/swiftpoet/test/FileSpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/FileSpecTests.kt
@@ -366,7 +366,40 @@ class FileSpecTests {
       )
     )
   }
+  @Test
+  @DisplayName("Emits local module types without import")
+  fun testLocalTypesAreNotImported() {
+    val type =
+      TypeSpec.structBuilder("SomeType")
+        .addProperty(
+          PropertySpec.varBuilder(
+            "myStuff",
+            typeName(".MyStuff")
+          ).build()
+        )
+        .build()
 
+    val testFile = FileSpec.builder("Test", "Test")
+      .addType(type)
+      .build()
+
+    val out = StringWriter()
+    testFile.writeTo(out)
+
+    assertThat(
+      out.toString(),
+      equalTo(
+        """
+            struct SomeType {
+
+              var myStuff: MyStuff
+
+            }
+
+        """.trimIndent()
+      )
+    )
+  }
   @Test
   @DisplayName("Generates guarded imports")
   fun testGenGuardedImports() {


### PR DESCRIPTION
This does two things...

1. Stops attempting to import "local" types (i.e. types without a module).
2. Requires that names are not blank when building an `ImportSpec`.