### PR TITLE
Always qualify ambiguous types

### DIFF
--- a/src/test/java/io/outfoxx/swiftpoet/test/FileSpecTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/FileSpecTests.kt
@@ -268,7 +268,7 @@ class FileSpecTests {
           
           class Test {
 
-            let a: Array
+            let a: Swift.Array
             let b: Foundation.Array
 
           }
@@ -290,7 +290,13 @@ class FileSpecTests {
       )
       .addProperty(
         PropertySpec.varBuilder(
-          "order",
+          "some_module_order",
+          typeName("some_module.SortOrder")
+        ).build()
+      )
+      .addProperty(
+        PropertySpec.varBuilder(
+          "some_other_module_order",
           typeName("some_other_module.SortOrder")
         ).build()
       )
@@ -308,12 +314,14 @@ class FileSpecTests {
       equalTo(
         """
             import Foundation
+            import some_module
             import some_other_module
 
             struct SomeType {
 
               var foundation_order: Foundation.SortOrder
-              var order: SortOrder
+              var some_module_order: some_module.SortOrder
+              var some_other_module_order: some_other_module.SortOrder
 
             }
 
@@ -357,7 +365,7 @@ class FileSpecTests {
 
             struct SomeType {
 
-              var foundation_order: SortOrder
+              var foundation_order: Foundation.SortOrder
               var order: some_other_module.SortOrder
 
             }


### PR DESCRIPTION
In [this](https://github.com/outfoxx/swiftpoet/pull/97/files#diff-3eb9e4a966de31a94296a10f7d7ef6030b1fca57b480c78891fb6419bf3eab82R283) PR  if we find ambiguous types we do not qualify them all. The test case was written against Foundation types which are almost always implicitly available so any file that was producing such output was successfully compiling.

A problem arises when the types that collide are _not_ within Foundation system framework but rather some custom frameworks.

This logic here updates to always qualify them if there are more than one found for a given type.