### PR TITLE
Support generic qualifiers for `TypeName`

### DIFF
--- a/api/swiftpoet.api
+++ b/api/swiftpoet.api
@@ -424,6 +424,25 @@ public final class io/outfoxx/swiftpoet/FunctionTypeName$Companion {
 	public static synthetic fun get$default (Lio/outfoxx/swiftpoet/FunctionTypeName$Companion;[Lio/outfoxx/swiftpoet/TypeName;Lio/outfoxx/swiftpoet/TypeName;ILjava/lang/Object;)Lio/outfoxx/swiftpoet/FunctionTypeName;
 }
 
+public final class io/outfoxx/swiftpoet/GenericQualifiedTypeName : io/outfoxx/swiftpoet/TypeName {
+	public static final field Companion Lio/outfoxx/swiftpoet/GenericQualifiedTypeName$Companion;
+	public final fun getQualifier ()Lio/outfoxx/swiftpoet/GenericQualifier;
+	public final fun getType ()Lio/outfoxx/swiftpoet/TypeName;
+}
+
+public final class io/outfoxx/swiftpoet/GenericQualifiedTypeName$Companion {
+	public final fun any (Lio/outfoxx/swiftpoet/TypeName;)Lio/outfoxx/swiftpoet/GenericQualifiedTypeName;
+	public final fun of (Lio/outfoxx/swiftpoet/TypeName;Lio/outfoxx/swiftpoet/GenericQualifier;)Lio/outfoxx/swiftpoet/GenericQualifiedTypeName;
+	public final fun some (Lio/outfoxx/swiftpoet/TypeName;)Lio/outfoxx/swiftpoet/GenericQualifiedTypeName;
+}
+
+public final class io/outfoxx/swiftpoet/GenericQualifier : java/lang/Enum {
+	public static final field ANY Lio/outfoxx/swiftpoet/GenericQualifier;
+	public static final field SOME Lio/outfoxx/swiftpoet/GenericQualifier;
+	public static fun valueOf (Ljava/lang/String;)Lio/outfoxx/swiftpoet/GenericQualifier;
+	public static fun values ()[Lio/outfoxx/swiftpoet/GenericQualifier;
+}
+
 public final class io/outfoxx/swiftpoet/ImportSpec : io/outfoxx/swiftpoet/AttributedSpec, java/lang/Comparable {
 	public static final field Companion Lio/outfoxx/swiftpoet/ImportSpec$Companion;
 	public static final fun builder (Ljava/lang/String;)Lio/outfoxx/swiftpoet/ImportSpec$Builder;
@@ -649,6 +668,7 @@ public abstract class io/outfoxx/swiftpoet/TypeName {
 	public fun makeNonImplicit ()Lio/outfoxx/swiftpoet/TypeName;
 	public fun makeNonOptional ()Lio/outfoxx/swiftpoet/TypeName;
 	public fun makeOptional ()Lio/outfoxx/swiftpoet/ParameterizedTypeName;
+	public fun qualify (Lio/outfoxx/swiftpoet/GenericQualifier;)Lio/outfoxx/swiftpoet/GenericQualifiedTypeName;
 	public fun toString ()Ljava/lang/String;
 	public fun unwrapOptional ()Lio/outfoxx/swiftpoet/TypeName;
 	public fun wrapOptional ()Lio/outfoxx/swiftpoet/ParameterizedTypeName;

--- a/src/main/java/io/outfoxx/swiftpoet/GenericQualifiedTypeName.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/GenericQualifiedTypeName.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.swiftpoet
+
+/**
+ * Qualify a [TypeName] with a [GenericQualifier] (any or some).
+ *
+ * `DataProtocol` qualified with `any` is
+ * ```
+ *   any DataProtocol
+ * ```
+ */
+class GenericQualifiedTypeName internal constructor(
+  val type: TypeName,
+  val qualifier: GenericQualifier,
+) : TypeName() {
+
+  override fun emit(out: CodeWriter): CodeWriter {
+    out.emitCode("${qualifier.name.lowercase()} ")
+    if (type is ComposedTypeName || type is GenericQualifiedTypeName) {
+      out.emitCode("(%T)", type)
+    } else {
+      out.emitCode("%T", type)
+    }
+    return out
+  }
+
+  companion object {
+
+    fun of(type: TypeName, qualifier: GenericQualifier): GenericQualifiedTypeName {
+      return GenericQualifiedTypeName(type, qualifier)
+    }
+
+    fun any(type: TypeName): GenericQualifiedTypeName {
+      return of(type, GenericQualifier.ANY)
+    }
+
+    fun some(type: TypeName): GenericQualifiedTypeName {
+      return of(type, GenericQualifier.SOME)
+    }
+  }
+}

--- a/src/main/java/io/outfoxx/swiftpoet/GenericQualifier.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/GenericQualifier.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.swiftpoet
+
+/**
+ * Generic qualifier for a [TypeName].
+ */
+enum class GenericQualifier {
+  ANY,
+  SOME
+}

--- a/src/main/java/io/outfoxx/swiftpoet/TypeName.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/TypeName.kt
@@ -58,6 +58,9 @@ abstract class TypeName internal constructor() {
 
   open fun makeNonImplicit(): TypeName = this
 
+  open fun qualify(qualifier: GenericQualifier): GenericQualifiedTypeName =
+    GenericQualifiedTypeName.of(this, qualifier)
+
   open val name: String
     get() {
       val out = StringWriter()

--- a/src/test/java/io/outfoxx/swiftpoet/test/GenericQualifiedTypeNameTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/GenericQualifiedTypeNameTests.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.swiftpoet.test
+
+import io.outfoxx.swiftpoet.ComposedTypeName
+import io.outfoxx.swiftpoet.DeclaredTypeName
+import io.outfoxx.swiftpoet.GenericQualifiedTypeName
+import io.outfoxx.swiftpoet.GenericQualifier
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class GenericQualifiedTypeNameTests {
+
+  @Test
+  @DisplayName("Generates generic qualified using explicit builders")
+  fun genericQualifiedTypeNameExplicit() {
+    val type = DeclaredTypeName.typeName(".GenericType")
+
+    assertThat(GenericQualifiedTypeName.any(type).name, equalTo("any GenericType"))
+    assertThat(GenericQualifiedTypeName.some(type).name, equalTo("some GenericType"))
+  }
+
+  @Test
+  @DisplayName("Generates generic qualified declared type names")
+  fun genericQualifiedDeclaredTypeName() {
+    val type = DeclaredTypeName.typeName(".GenericType")
+
+    assertThat(type.qualify(GenericQualifier.ANY).name, equalTo("any GenericType"))
+    assertThat(type.qualify(GenericQualifier.SOME).name, equalTo("some GenericType"))
+  }
+
+  @Test
+  @DisplayName("Generates generic qualified composite type names")
+  fun genericQualifiedCompositeTypeName() {
+    val typeA = DeclaredTypeName.typeName(".A")
+    val typeB = DeclaredTypeName.typeName(".B")
+    val typeC = DeclaredTypeName.typeName(".C")
+    val composed = ComposedTypeName.composed(typeA, typeB, typeC)
+
+    assertThat(composed.qualify(GenericQualifier.ANY).name, equalTo("any (A & B & C)"))
+    assertThat(composed.qualify(GenericQualifier.SOME).name, equalTo("some (A & B & C)"))
+  }
+}


### PR DESCRIPTION
Allows qualifying a `TypeName` with a generic qaulifier (`some` or `any`).

You qualify a type explicitly or using convenience on `TypeName`:
```swift
val myType = DeclaredTypeName.typeName(".MyType")

// Explicitly
GenericQualifiedTypeName.any(myType) // -> any MyType

// Convenience
myType.qualify(GenericQualifier.Any) // -> any MyType
```

Fixes #114 