### PR TITLE
Fix shortening of nested names in generated hierarchies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ gradle-app.setting
 
 run
 /.idea
+.mise.toml


### PR DESCRIPTION
This treats `ExternalTypeSpec` and `TypeSpec` differently when resolving short names. Logically it makes sense because we basically assume that any nested `DeclaredTypeName` can be nested in a n `ExternalTypeSpec`, simply because there is no way to know what children it actually has.

A test was added for the case we found but, additionally, I added a test to ensure that nested naming for generated code (i.e. from `TypeSpec` other than `ExternalTypeSpec`) is handled the same way in extensions.
