### PR TITLE
Fix string literals escaping logic

### DIFF
--- a/src/main/java/io/outfoxx/swiftpoet/Util.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/Util.kt
@@ -87,32 +87,17 @@ internal fun stringLiteralWithQuotes(
 ): String {
   if (!isConstantContext && '\n' in value) {
     val result = StringBuilder(value.length + 32)
-    result.append("\"\"\"\n|")
-    var i = 0
-    while (i < value.length) {
-      val c = value[i]
-      if (value.regionMatches(i, "\"\"\"", 0, 3)) {
-        // Don't inadvertently end the raw string too early
-        result.append("\"\"\${'\"'}")
-        i += 2
-      } else if (c == '\n') {
-        // Add a '|' after newlines. This pipe will be removed by trimMargin().
-        result.append("\n|")
-      } else {
-        result.append(c)
-      }
-      i++
-    }
-    // If the last-emitted character wasn't a margin '|', add a blank line. This will get removed
-    // by trimMargin().
-    if (!value.endsWith("\n")) result.append("\n")
-    result.append("\"\"\".trimMargin()")
+    // Start Swift multiline string
+    result.append("\"\"\"\n")
+    val escaped = value.replace("\"\"\"", "\\\"\"\"")
+    result.append(escaped)// End Swift multiline string
+    result.append("\n\"\"\"")
     return result.toString()
   } else {
     val result = StringBuilder(value.length + 32)
     // Using pre-formatted strings allows us to get away with not escaping symbols that would
     // normally require escaping, e.g. "foo ${"bar"} baz".
-    if (isInsideRawString) result.append("\"\"\"") else result.append('"')
+    if (isInsideRawString) result.append("\"\"\"\n") else result.append('"')
     for (c in value) {
       // Trivial case: single quote must not be escaped.
       if (c == '\'') {
@@ -128,7 +113,7 @@ internal fun stringLiteralWithQuotes(
       result.append(if (isInsideRawString) c else characterLiteralWithoutSingleQuotes(c))
       // Need to append indent after linefeed?
     }
-    if (isInsideRawString) result.append("\"\"\"") else result.append('"')
+    if (isInsideRawString) result.append("\n\"\"\"") else result.append('"')
     return result.toString()
   }
 }

--- a/src/main/java/io/outfoxx/swiftpoet/Util.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/Util.kt
@@ -90,7 +90,7 @@ internal fun stringLiteralWithQuotes(
     // Start Swift multiline string
     result.append("\"\"\"\n")
     val escaped = value.replace("\"\"\"", "\\\"\"\"")
-    result.append(escaped)// End Swift multiline string
+    result.append(escaped) // End Swift multiline string
     result.append("\n\"\"\"")
     return result.toString()
   } else {

--- a/src/main/java/io/outfoxx/swiftpoet/Util.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/Util.kt
@@ -98,9 +98,6 @@ internal fun stringLiteralWithQuotes(
       } else if (c == '\n') {
         // Add a '|' after newlines. This pipe will be removed by trimMargin().
         result.append("\n|")
-      } else if (c == '$' && !isInsideRawString) {
-        // Escape '$' symbols with ${'$'}.
-        result.append("\${\'\$\'}")
       } else {
         result.append(c)
       }
@@ -125,11 +122,6 @@ internal fun stringLiteralWithQuotes(
       // Trivial case: double quotes must be escaped.
       if (c == '\"' && !isInsideRawString) {
         result.append("\\\"")
-        continue
-      }
-      // Trivial case: $ signs must be escaped.
-      if (c == '$' && !isInsideRawString) {
-        result.append("\${\'\$\'}")
         continue
       }
       // Default case: just let character literal do its work.

--- a/src/main/java/io/outfoxx/swiftpoet/Util.kt
+++ b/src/main/java/io/outfoxx/swiftpoet/Util.kt
@@ -36,13 +36,6 @@ internal fun <T> Collection<T>.toImmutableSet(): Set<T> =
 internal inline fun <reified T : Enum<T>> Collection<T>.toEnumSet(): Set<T> =
   enumValues<T>().filterTo(mutableSetOf(), this::contains)
 
-internal fun requireExactlyOneOf(modifiers: Set<Modifier>, vararg mutuallyExclusive: Modifier) {
-  val count = mutuallyExclusive.count(modifiers::contains)
-  require(count == 1) {
-    "modifiers $modifiers must contain one of ${mutuallyExclusive.contentToString()}"
-  }
-}
-
 internal fun requireNoneOrOneOf(modifiers: Set<Modifier>, vararg mutuallyExclusive: Modifier) {
   val count = mutuallyExclusive.count(modifiers::contains)
   require(count <= 1) {
@@ -50,16 +43,8 @@ internal fun requireNoneOrOneOf(modifiers: Set<Modifier>, vararg mutuallyExclusi
   }
 }
 
-internal fun requireNoneOf(modifiers: Set<Modifier>, vararg forbidden: Modifier) {
-  require(forbidden.none(modifiers::contains)) {
-    "modifiers $modifiers must contain none of ${forbidden.contentToString()}"
-  }
-}
-
 internal fun <T> T.isOneOf(t1: T, t2: T, t3: T? = null, t4: T? = null, t5: T? = null, t6: T? = null) =
   this == t1 || this == t2 || this == t3 || this == t4 || this == t5 || this == t6
-
-internal fun <T> Collection<T>.containsAnyOf(vararg t: T) = t.any(this::contains)
 
 // see https://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.10.6
 internal fun characterLiteralWithoutSingleQuotes(c: Char) = when {

--- a/src/test/java/io/outfoxx/swiftpoet/test/UtilTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/UtilTests.kt
@@ -65,10 +65,17 @@ class UtilTests {
     stringLiteral("abc")
     stringLiteral("♦♥♠♣")
     stringLiteral("€\\t@\\t$", "€\t@\t$")
-    assertThat(stringLiteralWithQuotes("abc();\ndef();"), equalTo("\"\"\"\n|abc();\n|def();\n\"\"\".trimMargin()"))
+    assertThat(stringLiteralWithQuotes("abc();\ndef();"), equalTo("\"\"\"\nabc();\ndef();\n\"\"\""))
     stringLiteral("This is \\\"quoted\\\"!", "This is \"quoted\"!")
     stringLiteral("😀", "😀")
     stringLiteral("e^{i\\\\pi}+1=0", "e^{i\\pi}+1=0")
+    assertThat(
+      stringLiteralWithQuotes("a \"\"\" b\nc"),
+      equalTo("\"\"\"\n" +
+              "a \\\"\"\" b\n" +
+              "c\n" +
+              "\"\"\"")
+    )
     assertThat(stringLiteralWithQuotes("abc();\ndef();", isConstantContext = true), equalTo("\"abc();\\ndef();\""))
   }
 

--- a/src/test/java/io/outfoxx/swiftpoet/test/UtilTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/UtilTests.kt
@@ -71,10 +71,12 @@ class UtilTests {
     stringLiteral("e^{i\\\\pi}+1=0", "e^{i\\pi}+1=0")
     assertThat(
       stringLiteralWithQuotes("a \"\"\" b\nc"),
-      equalTo("\"\"\"\n" +
-              "a \\\"\"\" b\n" +
-              "c\n" +
-              "\"\"\"")
+      equalTo(
+        "\"\"\"\n" +
+          "a \\\"\"\" b\n" +
+          "c\n" +
+          "\"\"\""
+      )
     )
     assertThat(stringLiteralWithQuotes("abc();\ndef();", isConstantContext = true), equalTo("\"abc();\\ndef();\""))
   }

--- a/src/test/java/io/outfoxx/swiftpoet/test/UtilTests.kt
+++ b/src/test/java/io/outfoxx/swiftpoet/test/UtilTests.kt
@@ -64,7 +64,7 @@ class UtilTests {
   @Test fun stringLiteral() {
     stringLiteral("abc")
     stringLiteral("♦♥♠♣")
-    stringLiteral("€\\t@\\t\${\'\$\'}", "€\t@\t$")
+    stringLiteral("€\\t@\\t$", "€\t@\t$")
     assertThat(stringLiteralWithQuotes("abc();\ndef();"), equalTo("\"\"\"\n|abc();\n|def();\n\"\"\".trimMargin()"))
     stringLiteral("This is \\\"quoted\\\"!", "This is \"quoted\"!")
     stringLiteral("😀", "😀")


### PR DESCRIPTION
The `stringLiteralWithQuotes` had some leftover Kotlin string escaping logic that had to be cleaned up:

1. Dollar sign escaping: in Swift, the dollar sign should not be escaped as `$` → `${'$'}` – this
  breaks emitting the intended string literal.
2. `.trimMargin` doesn’t exist for Swift multiline strings, so the code would fail to compile if
  we attempted something like that.
3. Multiline literals in Swift should be formatted as:

```
"""
abc();
def();
"""
```

Not 

```
"""
|abc();
|def();
""".trimMargin()
```

---

**Before:**

`€\t@\t${'$'}` -> `"€\\t@\\t${'$'}{'${'$'}'}"`

`"\"ab$c();\\ndef();\""` -> `"\"ab${'$'}c();\\ndef();\""`

```
"abc();\ndef();" -> """
|abc();
|def();
""".trimMargin()
```

**After:**

`€\t@\t${'$'}` -> `"€\\t@\\t${'$'}"`

`"\"ab$c();\\ndef();\""` -> `"\"ab$c();\\ndef();\""`

```
"abc();\ndef();" -> """
abc();
def();
"""
```